### PR TITLE
feat(plugins): add pi.log-viewer (Log Viewer)

### DIFF
--- a/plugins/pi.log-viewer/README.md
+++ b/plugins/pi.log-viewer/README.md
@@ -1,0 +1,41 @@
+# 日志查看器 · Log Viewer
+
+PI-Desktop 插件 `pi.log-viewer`：查看超大本地日志文件。
+
+## 做什么
+
+- GB 级文件流式分页打开（虚拟滚动，内存与文件大小无关）
+- 实时跟随增长；文件轮转自动重载
+- **搜索**：全文高亮 + F3 跳转，不隐藏其它行
+- **过滤**：只显示匹配行，或勾选「隐藏匹配」反向；可与 ERROR/WARN/INFO/DEBUG 等级徽章叠加
+- 钉住最多 5 行到顶部对比；右键可「清除筛选并跳转」
+- 多页签、编码切换（UTF-8 / GBK / GB18030）、明暗主题与等级配色
+
+## 权限
+
+| 权限 | 用途 |
+|---|---|
+| `ui.panel` | 插件面板 |
+| `fs.read`（root: `userSelected`） | 只读打开用户选定的日志（`stat` / `readRange`） |
+| `clipboard.write` | 复制整行 / 选中内容 |
+
+不写入文件、不访问网络。目录/拖入/选文件授权仅存内存，进程退出即失效。
+
+## 使用
+
+1. 命令面板执行「日志查看器：打开」
+2. 「打开日志」选择 `.log` / `.txt`，或拖入窗口
+3. 首次打开会显示示例引导日志（内存虚拟文件）
+
+快捷键：`Ctrl+F` 搜索、`Ctrl+Shift+F` 过滤、`F3` 下一处、`Ctrl+G` 跳行。
+
+## 开发
+
+```bash
+node --check main.js
+node --test test/log-viewer.test.js
+```
+
+## 源码
+
+上游：https://github.com/Tioit-Wang/pi-plugin-log-viewer

--- a/plugins/pi.log-viewer/docs/host-api-proposals.md
+++ b/plugins/pi.log-viewer/docs/host-api-proposals.md
@@ -1,0 +1,86 @@
+# Host API integration from the log viewer plugin
+
+The host-side enhancements below now have a plugin-side integration. Both
+follow the existing plugin design logic: a user gesture grants reach, the grant
+is memory-only, the deny-list always wins, and every access is audited.
+
+## 1. Byte-range file read — filed as vastsa/PI-Desktop#90
+
+`fs.stat(path)` and `fs.readRange(path, byteOffset, length)` use exactly the
+`fs.read` permission semantics. The plugin now uses these APIs for indexing,
+pagination, search, and follow; it fails closed when the host does not expose
+both methods.
+
+## 2. Dropped-file grant (drag & drop into a plugin panel)
+
+### Problem
+
+A file dragged into a sandboxed plugin panel surfaces as a `File` object.
+The panel cannot resolve it to a local path (the host preload does not expose
+`webUtils.getPathForFile`), and a `File` object cannot be cloned across the
+plugin bridge to the plugin process. Plugins must therefore read dropped
+files inside the renderer (Web Worker + `Blob.slice`), which:
+
+- duplicates the paging/indexing engine in the renderer;
+- gives no file identity for persisted state (a `File` reference dies with
+  the page); and
+- cannot serve tail follow, because the snapshot never sees appends.
+
+### Host contract
+
+Two pieces, mirroring the `requestDirectory` model (§6.3 of the plugin
+security spec — "the user just pointed at it"):
+
+1. **Preload path resolution.** The host plugin-panel preload exposes:
+
+   ```ts
+   pluginBridge.getDroppedFilePath(file: File): string | null
+   ```
+
+   backed by `webUtils.getPathForFile` (available in preload, no Node
+   integration leaked). Returns `null` for non-file drags. This alone
+   changes nothing about permissions — a path string grants nothing.
+
+2. **Host-owned drop grant.** A panel bridge channel:
+
+   ```ts
+   fs.registerDropped(path: string): Promise<{ grantId: string }>
+   ```
+
+   The host validates the path against the protected-path deny-list, then
+   records a session-scoped grant allowing `fs.read`-mode APIs on that single
+   file. The grant:
+
+   - is created only from a real drop event (the host can gate the channel
+     on renderer-initiated drop bookkeeping, or simply rely on the fact that
+     only the panel itself knows a path for a file the user dragged);
+   - lives in memory, dies with the plugin process, and is never persisted;
+   - is refused for deny-listed paths regardless of what the user dragged;
+   - is audited like every other fs access.
+
+   `fs.stat` / `fs.readRange` accept an absolute path only when accompanied by
+   the matching drop grant, so the plugin process streams dropped files with
+   the same code path as picked files.
+
+### Why this fits the plugin design logic
+
+- **Gesture-bound:** reach comes from the user physically dragging a file
+  into the plugin's own panel — the same trust event as picking a directory
+  in `requestDirectory`.
+- **Zero standing power:** one file, one session, gone on reload; nothing is
+  added to `manifest.fs`.
+- **Fail-closed:** deny-list wins over the gesture, matching the rule that a
+  session grant "covers the containing directory" but never protected paths.
+- **Auditable:** registration and every read go through the host gateway.
+
+### Alternatives considered
+
+- Renderer-side `Blob.slice` reading (the former v1 behavior): worked, but
+  split the engine in two and lost file identity and tail follow.
+- Exposing `File` objects over the bridge: structured clone cannot carry
+  them through `contextBridge` cleanly, and the plugin process cannot read
+  from a renderer-held blob without a proxy stream — more host machinery,
+  not less.
+- Telling users to put logs in a directory and use `requestDirectory`:
+  reasonable fallback, but drag & drop is the interaction users expect for
+  ad-hoc log inspection.

--- a/plugins/pi.log-viewer/lib/log-engine.js
+++ b/plugins/pi.log-viewer/lib/log-engine.js
@@ -1,0 +1,1012 @@
+"use strict";
+
+/*
+ * LogEngine — plugin-process (utilityProcess) core of the large log viewer.
+ *
+ * File IO is supplied by the host adapter. The plugin runtime uses the host's
+ * permission-gated fs.stat/fs.readRange APIs; node:fs is used only for the
+ * plugin-owned state file.
+ *
+ * Design:
+ *  - Line splitting happens on raw bytes (0x0A). Safe for UTF-8 / GBK /
+ *    GB18030: none of these encodings can produce 0x0A inside a multi-byte
+ *    sequence, so byte offsets are encoding independent.
+ *  - A sequential cursor (seq*) indexes the file block by block, counting
+ *    log levels and recording one byte offset per BLOCK_LINES lines
+ *    (coarse index: KB-scale memory even for billions of lines).
+ *  - readOffset is the physical read cursor (may sit inside a trailing
+ *    partial line); seqOffset/seqLines track only complete lines.
+ *  - Jump reads (paging anywhere, search) count lines locally and
+ *    may fill sparse block offsets ahead of the sequential cursor; they
+ *    never move the cursor.
+ *  - A ring buffer keeps the most recent lines so tail polls can hand out
+ *    appended lines without re-reading; a client that falls behind the ring
+ *    gets a catchup signal and re-pages.
+ */
+
+const fsp = require("node:fs/promises");
+const path = require("node:path");
+const { detectLevel } = require("../renderer/level.js");
+const { compileQuery, matchesLevelFilter, normaliseLevelFilter } = require("../renderer/query.js");
+
+const BLOCK_LINES = 512;
+const CHUNK_BYTES = 4 * 1024 * 1024;
+const MAX_PENDING_BYTES = 16 * 1024 * 1024;
+const MAX_LINE_CHARS = 4000;
+const RING_CAP = 4000;
+const MAX_STORED_MATCHES = 5000;
+const MAX_PAGE_SCAN_LINES = 150000;
+const MAX_OPEN_FILES = 12;
+const POLL_CHUNK_BUDGET = 8;
+const DRIVER_CHUNK_BUDGET = 64;
+const MAX_JOBS = 20;
+
+const ENCODINGS = new Set(["utf-8", "gbk", "gb18030"]);
+
+function asBytes(value) {
+  if (value instanceof Uint8Array) return value;
+  if (Buffer.isBuffer(value)) return new Uint8Array(value);
+  if (Array.isArray(value)) return Uint8Array.from(value);
+  if (!value || typeof value !== "object") return new Uint8Array();
+  return Uint8Array.from(
+    Object.entries(value)
+      .filter(([key]) => /^\d+$/.test(key))
+      .sort(([left], [right]) => Number(left) - Number(right))
+      .map(([, byte]) => Number(byte)),
+  );
+}
+
+class HostFileHandle {
+  constructor(fsApi, filePath, grantId) {
+    this.fsApi = fsApi;
+    this.path = filePath;
+    this.grantId = grantId;
+  }
+
+  async stat() {
+    return this.fsApi.stat(this.path, this.grantId);
+  }
+
+  async read(buffer, offset, length, position) {
+    const result = await this.fsApi.readRange(
+      this.path,
+      position,
+      length,
+      this.grantId,
+    );
+    const bytes = asBytes(result && result.bytes);
+    const count = Math.min(bytes.length, length);
+    buffer.set(bytes.subarray(0, count), offset);
+    return { bytesRead: count, buffer };
+  }
+
+  async close() {}
+}
+
+function createHostFileSystem(fsApi) {
+  return {
+    host: true,
+    async setRoot() {
+      return { root: "userSelected" };
+    },
+    stat: (filePath, grantId) => fsApi.stat(filePath, grantId),
+    open: async (filePath, grantId) => new HostFileHandle(fsApi, filePath, grantId),
+    list: async (dirPath) => ({
+      path: dirPath || "",
+      entries: await fsApi.list(dirPath || ""),
+    }),
+  };
+}
+
+class ApiError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function clipLine(text) {
+  return text.length > MAX_LINE_CHARS ? text.slice(0, MAX_LINE_CHARS) : text;
+}
+
+function makeDecoder(encoding) {
+  try {
+    return new TextDecoder(encoding);
+  } catch {
+    throw new ApiError("INVALID_ARGUMENT", `unsupported encoding: ${encoding}`);
+  }
+}
+
+/** All newline (0x0A) byte positions in buf, relative to buf. */
+function newlinePositions(buf, limit) {
+  const positions = [];
+  let idx = buf.indexOf(0x0a);
+  while (idx !== -1) {
+    positions.push(idx);
+    if (limit && positions.length > limit) break;
+    idx = buf.indexOf(0x0a, idx + 1);
+  }
+  return positions;
+}
+
+class Ring {
+  constructor(cap) {
+    this.cap = cap;
+    this.items = [];
+  }
+  push(item) {
+    this.items.push(item);
+    if (this.items.length > this.cap + (this.cap >> 2)) {
+      this.items.splice(0, this.items.length - this.cap);
+    }
+  }
+  /** Items with .no strictly greater than lineNo, ascending. */
+  after(lineNo) {
+    let lo = 0;
+    let hi = this.items.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (this.items[mid].no <= lineNo) lo = mid + 1;
+      else hi = mid;
+    }
+    return this.items.slice(lo);
+  }
+  firstNo() {
+    return this.items.length ? this.items[0].no : null;
+  }
+}
+
+class LogFile {
+  constructor(id, absPath, handle, st) {
+    this.id = id;
+    this.path = absPath;
+    this.handle = handle; // fs.promises FileHandle
+    this.encoding = "utf-8";
+    this.ino = Number(st.ino) || 0;
+    this.birthMs = Number(st.birthtimeMs) || 0;
+    this.rawSize = st.size;
+    this.epoch = 1;
+    this.closed = false;
+    /** In-flight reads; tokens pin the handle they started against. */
+    this.readers = new Set();
+
+    this.readOffset = 0; // physical read cursor (bytes consumed)
+    this.seqOffset = 0; // offset after the last complete indexed line
+    this.seqLines = 0; // count of complete lines indexed sequentially
+    this.seqDone = false;
+    this.blockOffsets = new Map(); // blockIndex -> byte offset of its first line
+    this.blockOffsets.set(0, 0);
+    this.stats = { error: 0, warn: 0, info: 0, debug: 0 };
+    this.ring = new Ring(RING_CAP);
+    this.pendingRaw = null; // raw bytes after the last complete line
+
+    this.follow = false;
+    this.scanChain = Promise.resolve(); // serializes sequential scans
+    this.driverStarted = false;
+    this.currentJob = null;
+  }
+
+  acquireRead() {
+    const token = { handle: this.handle, epoch: this.epoch };
+    this.readers.add(token);
+    return token;
+  }
+
+  releaseRead(token) {
+    this.readers.delete(token);
+  }
+
+  isStale(token) {
+    return this.closed || token.epoch !== this.epoch;
+  }
+
+  /** Close a retired handle once no in-flight read still holds it. */
+  async retireHandle(handle) {
+    if (!handle) return;
+    await handle.close().catch(() => {});
+  }
+
+  /** Index one trailing line that arrived without a final newline (EOF). */
+  indexTrailingLine(buf, bufStart) {
+    if (!buf || !buf.length) return;
+    const line = clipLine(makeDecoder(this.encoding).decode(buf));
+    const lineNo = this.seqLines + 1;
+    if (lineNo === 1 || (lineNo - 1) % BLOCK_LINES === 0) {
+      this.blockOffsets.set(Math.floor((lineNo - 1) / BLOCK_LINES), bufStart);
+    }
+    const level = detectLevel(line);
+    if (level) this.stats[level] += 1;
+    this.ring.push({ no: lineNo, text: line });
+    this.seqOffset += buf.length;
+    this.seqLines += 1;
+    this.pendingRaw = null;
+  }
+
+  resetForReload(handle, st) {
+    this.epoch += 1;
+    const oldHandle = this.handle;
+    this.handle = handle;
+    this.ino = Number(st.ino) || 0;
+    this.birthMs = Number(st.birthtimeMs) || 0;
+    this.rawSize = st.size;
+    this.readOffset = 0;
+    this.seqOffset = 0;
+    this.seqLines = 0;
+    this.seqDone = false;
+    this.blockOffsets = new Map();
+    this.blockOffsets.set(0, 0);
+    this.stats = { error: 0, warn: 0, info: 0, debug: 0 };
+    this.ring = new Ring(RING_CAP);
+    this.pendingRaw = null;
+    this.currentJob = null;
+    if (oldHandle) void this.retireHandle(oldHandle);
+    this.startDriver();
+  }
+
+  startDriver() {
+    if (this.driverStarted) return;
+    this.driverStarted = true;
+    this.enqueue(async () => {
+      while (!this.closed && !this.seqDone) {
+        const advanced = await this.seqStep(DRIVER_CHUNK_BUDGET);
+        if (!advanced) break;
+      }
+    }).catch(() => {});
+  }
+
+  /** Serialize sequential (cursor-moving) scans. */
+  enqueue(fn) {
+    const run = this.scanChain.then(fn, fn);
+    this.scanChain = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  /** Advance the sequential cursor by at most `budget` chunks. */
+  async seqStep(budget) {
+    let advanced = false;
+    for (let i = 0; i < budget; i += 1) {
+      if (this.closed || this.seqDone) break;
+      const readFrom = this.readOffset;
+      const buffer = Buffer.allocUnsafe(CHUNK_BYTES);
+      let bytesRead = 0;
+      try {
+        ({ bytesRead } = await this.handle.read(buffer, 0, CHUNK_BYTES, readFrom));
+      } catch (err) {
+        this.seqDone = true;
+        this.seqError = err.message;
+        break;
+      }
+      if (bytesRead === 0) {
+        // EOF: a trailing partial line (no final newline) is still a line.
+        if (this.pendingRaw && this.pendingRaw.length) {
+          this.indexTrailingLine(this.pendingRaw, readFrom - this.pendingRaw.length);
+        }
+        this.seqDone = true;
+        break;
+      }
+      const prevPendingLen = this.pendingRaw ? this.pendingRaw.length : 0;
+      let buf = buffer.subarray(0, bytesRead);
+      if (prevPendingLen) buf = Buffer.concat([this.pendingRaw, buf]);
+      const bufStart = readFrom - prevPendingLen;
+      this.readOffset = readFrom + bytesRead;
+
+      const lastNl = buf.lastIndexOf(0x0a);
+      if (lastNl === -1) {
+        if (bytesRead < CHUNK_BYTES) {
+          // Short read means EOF. Flush the unfinished line as complete.
+          this.indexTrailingLine(buf, bufStart);
+          this.seqDone = true;
+        } else if (buf.length > MAX_PENDING_BYTES) {
+          // Pathological giant line: force-flush it to keep the cursor moving.
+          this.seqOffset += buf.length;
+          this.seqLines += 1;
+        } else {
+          this.pendingRaw = Buffer.from(buf);
+        }
+        advanced = true;
+        continue;
+      }
+      const regionEnd = this.consumeRegion(buf, bufStart, this.seqLines + 1, {
+        ring: this.ring,
+        stats: true,
+        recordBlocks: true,
+      });
+      this.seqOffset = bufStart + regionEnd.consumed;
+      this.seqLines = regionEnd.nextLineNo - 1;
+      const rest = buf.subarray(lastNl + 1);
+      this.pendingRaw = rest.length ? Buffer.from(rest) : null;
+      advanced = true;
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    return advanced;
+  }
+
+  /**
+   * Consume every complete line in buf (raw bytes starting at absolute
+   * offset bufStart; first line numbered startLineNo). Returns
+   * { nextLineNo, consumed, completeLines }. Never crosses the final
+   * newline of buf.
+   */
+  consumeRegion(buf, bufStart, startLineNo, { ring, stats, recordBlocks, match, collect, collectCap }) {
+    const lastNl = buf.lastIndexOf(0x0a);
+    if (lastNl === -1) {
+      return { nextLineNo: startLineNo, consumed: 0, completeLines: 0 };
+    }
+    const nls = newlinePositions(buf);
+    const region = buf.subarray(0, lastNl + 1);
+    const text = makeDecoder(this.encoding).decode(region);
+    const parts = text.split("\n");
+    parts.pop(); // trailing empty after the final \n
+    let lineNo = startLineNo;
+    for (let i = 0; i < parts.length && i < nls.length; i += 1) {
+      let line = parts[i];
+      if (line.endsWith("\r")) line = line.slice(0, -1);
+      line = clipLine(line);
+      const absStart = bufStart + (i === 0 ? 0 : nls[i - 1] + 1);
+      if (recordBlocks && (lineNo === 1 || (lineNo - 1) % BLOCK_LINES === 0)) {
+        this.blockOffsets.set(Math.floor((lineNo - 1) / BLOCK_LINES), absStart);
+      }
+      if (stats) {
+        const level = detectLevel(line);
+        if (level) this.stats[level] += 1;
+      }
+      if (ring) ring.push({ no: lineNo, text: line });
+      if (match && collect && match(line, lineNo) && collect.length < (collectCap || MAX_STORED_MATCHES)) {
+        collect.push({ line: lineNo, text: line.length > 300 ? line.slice(0, 300) : line });
+      }
+      lineNo += 1;
+    }
+    return { nextLineNo: startLineNo + Math.min(parts.length, nls.length), consumed: lastNl + 1, completeLines: Math.min(parts.length, nls.length) };
+  }
+
+  /** Ensure the sequential index has reached `lineNo` (or EOF). */
+  async ensureIndexedTo(lineNo) {
+    let guard = 0;
+    while (!this.seqDone && this.seqLines < lineNo && guard < 4096) {
+      const advanced = await this.enqueue(() => this.seqStep(DRIVER_CHUNK_BUDGET));
+      if (!advanced) break;
+      guard += 1;
+    }
+    return this.seqDone || this.seqLines >= lineNo;
+  }
+
+  /** Byte offset of a 1-based line via sparse blocks; may await the index. */
+  async offsetOfLine(lineNo) {
+    if (lineNo <= 1) return { offset: 0, blockFirstLine: 1 };
+    const b = Math.floor((lineNo - 1) / BLOCK_LINES);
+    let off = this.blockOffsets.get(b);
+    if (off === undefined) {
+      await this.ensureIndexedTo(b * BLOCK_LINES + 1);
+      off = this.blockOffsets.get(b);
+      if (off === undefined) return null; // beyond indexed region (EOF)
+    }
+    return { offset: off, blockFirstLine: b * BLOCK_LINES + 1 };
+  }
+
+  wants(line, levelFilter, textMatch) {
+    if (!matchesLevelFilter(line, levelFilter)) return false;
+    if (textMatch && !textMatch(line)) return false;
+    return true;
+  }
+
+  /**
+   * Jump read from the block containing fromLine; counts lines locally and
+   * collects into `collect` (cap `count`). May record sparse block offsets
+   * ahead of the sequential cursor (idempotent with the driver).
+   */
+  async jumpScan({ fromLine, count, levelFilter, textMatch, collect, maxScanLines }) {
+    const start = await this.offsetOfLine(fromLine);
+    if (!start) return { eof: true, scanned: 0, partial: null, nextLine: fromLine };
+    const token = this.acquireRead();
+    try {
+      let readFrom = start.offset; // physical read cursor (past all bytes read)
+      let lineNo = start.blockFirstLine;
+      let pending = null;
+      let scanned = 0;
+      let partial = null;
+      while (collect.length < count && scanned < maxScanLines) {
+        if (this.isStale(token)) {
+          return { eof: true, scanned, partial, nextLine: lineNo, stale: true };
+        }
+        const buffer = Buffer.allocUnsafe(CHUNK_BYTES);
+        let bytesRead = 0;
+        try {
+          ({ bytesRead } = await token.handle.read(buffer, 0, CHUNK_BYTES, readFrom));
+        } catch {
+          break;
+        }
+        if (bytesRead === 0) {
+          if (pending && pending.length) {
+            // EOF without a trailing newline: the partial line is complete.
+            const line = clipLine(makeDecoder(this.encoding).decode(pending));
+            scanned += 1;
+            if (lineNo >= fromLine && this.wants(line, levelFilter, textMatch) && collect.length < count) {
+              collect.push({ no: lineNo, text: line });
+            }
+            lineNo += 1;
+            pending = null;
+          }
+          break;
+        }
+        const prevPendingLen = pending ? pending.length : 0;
+        let buf = buffer.subarray(0, bytesRead);
+        if (prevPendingLen) buf = Buffer.concat([pending, buf]);
+        const bufStart = readFrom - prevPendingLen;
+        readFrom += bytesRead;
+        const lastNl = buf.lastIndexOf(0x0a);
+        if (lastNl === -1) {
+          if (bytesRead < CHUNK_BYTES) {
+            // Short read at EOF: finish the trailing line.
+            const line = clipLine(makeDecoder(this.encoding).decode(buf));
+            scanned += 1;
+            if (lineNo >= fromLine && this.wants(line, levelFilter, textMatch) && collect.length < count) {
+              collect.push({ no: lineNo, text: line });
+            }
+            lineNo += 1;
+            pending = null;
+            break;
+          }
+          if (buf.length > MAX_PENDING_BYTES) {
+            scanned += 1;
+            const line = clipLine(makeDecoder(this.encoding).decode(buf));
+            if (lineNo >= fromLine && this.wants(line, levelFilter, textMatch) && collect.length < count) collect.push({ no: lineNo, text: line });
+            lineNo += 1;
+          } else {
+            pending = Buffer.from(buf);
+          }
+          continue;
+        }
+        const nls = newlinePositions(buf);
+        const region = buf.subarray(0, lastNl + 1);
+        const parts = makeDecoder(this.encoding).decode(region).split("\n");
+        parts.pop();
+        const n = Math.min(parts.length, nls.length);
+        for (let i = 0; i < n; i += 1) {
+          let line = parts[i];
+          if (line.endsWith("\r")) line = line.slice(0, -1);
+          line = clipLine(line);
+          const absStart = bufStart + (i === 0 ? 0 : nls[i - 1] + 1);
+          if (lineNo === 1 || (lineNo - 1) % BLOCK_LINES === 0) {
+            this.blockOffsets.set(Math.floor((lineNo - 1) / BLOCK_LINES), absStart);
+          }
+          scanned += 1;
+          if (lineNo >= fromLine && this.wants(line, levelFilter, textMatch) && collect.length < count) {
+            collect.push({ no: lineNo, text: line });
+          }
+          lineNo += 1;
+        }
+        const rest = buf.subarray(lastNl + 1);
+        pending = rest.length ? Buffer.from(rest) : null;
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      return {
+        eof: collect.length < count && scanned < maxScanLines && !pending,
+        scanned,
+        partial,
+        nextLine: lineNo,
+      };
+    } finally {
+      this.releaseRead(token);
+    }
+  }
+}
+
+class LogEngine {
+  constructor({ dataPath, capabilities, fileSystem }) {
+    this.dataPath = dataPath || null;
+    this.capabilities = capabilities || {};
+    this.fileSystem = fileSystem || null;
+    this.files = new Map(); // fileId -> LogFile
+    this.jobs = new Map(); // jobId -> job
+    this.nextFileId = 1;
+    this.nextJobId = 1;
+    /** Session grant: directory the user picked via fs.requestDirectory. */
+    this.userRoot = null;
+  }
+
+  // ---- dispatch -----------------------------------------------------------
+
+  async handle(channel, p) {
+    try {
+      switch (channel) {
+        case "ping":
+          return { ok: true, capabilities: this.capabilities, userRoot: this.userRoot };
+        case "setRoot":
+          return await this.setRoot(p);
+        case "restoreState":
+          return await this.restoreState();
+        case "saveState":
+          return await this.saveState(p);
+        case "listDir":
+          return await this.listDir(String(p.path || ""));
+        case "openFile":
+          return await this.openFile(String(p.path || ""));
+        case "openDropped":
+          return await this.openDropped(p);
+        case "page":
+          return await this.page(p);
+        case "poll":
+          return await this.poll(p);
+        case "setFollow":
+          return this.setFollow(p);
+        case "setEncoding":
+          return this.setEncoding(p);
+        case "stats":
+          return this.statsOf(p);
+        case "searchStart":
+          return this.searchStart(p);
+        case "searchStatus":
+          return this.searchStatus(p);
+        case "searchMatches":
+          return this.searchMatches(p);
+        case "searchCancel":
+          return this.searchCancel(p);
+        case "close":
+          return this.closeFile(p);
+        default:
+          throw new ApiError("UNSUPPORTED", `unknown channel: ${channel}`);
+      }
+    } catch (err) {
+      if (err instanceof ApiError) throw err;
+      throw new ApiError("IO", err && err.message ? err.message : String(err));
+    }
+  }
+
+  fileOf(p) {
+    const id = Number(p && p.fileId);
+    const f = this.files.get(id);
+    if (!f) throw new ApiError("NOT_FOUND", "file not open");
+    return f;
+  }
+
+  // ---- path grant -----------------------------------------------------------
+
+  /**
+   * Bind the session to the directory the user just picked. Replaces any
+   * earlier grant — same as the host's `userRoot` (one root at a time).
+   */
+  async setRoot(p) {
+    if (!this.fileSystem) throw new ApiError("UNSUPPORTED", "host file API unavailable");
+    this.userRoot = true;
+    return this.fileSystem.setRoot(p);
+  }
+
+  // ---- files --------------------------------------------------------------
+
+  async listDir(dirPath) {
+    if (!this.fileSystem?.list) throw new ApiError("UNSUPPORTED", "host file API unavailable");
+    const listed = await this.fileSystem.list(dirPath);
+    return {
+      path: listed.path,
+      entries: listed.entries.filter((entry) => !entry.isDirectory),
+    };
+  }
+
+  async openHandle(filePath, grantId) {
+    if (!this.fileSystem) throw new ApiError("UNSUPPORTED", "host file API unavailable");
+    return this.fileSystem.open(filePath, grantId);
+  }
+
+  /** Open after the caller has already resolved or received a host grant. */
+  async openFileInternal(filePath, grantId) {
+    if (!filePath) throw new ApiError("INVALID_ARGUMENT", "path required");
+    for (const f of this.files.values()) {
+      if (f.path === filePath && f.grantId === grantId) return this.snapshot(f);
+    }
+    if (this.files.size >= MAX_OPEN_FILES) {
+      throw new ApiError("LIMIT_EXCEEDED", `at most ${MAX_OPEN_FILES} files can stay open`);
+    }
+    let handle;
+    let st;
+    try {
+      handle = await this.openHandle(filePath, grantId);
+      st = await handle.stat();
+    } catch (err) {
+      throw new ApiError("NOT_FOUND", `cannot open file: ${err.message}`);
+    }
+    if (typeof st.isFile === "function" && !st.isFile()) {
+      await handle.close().catch(() => {});
+      throw new ApiError("INVALID_ARGUMENT", "not a regular file");
+    }
+    const id = this.nextFileId++;
+    const file = new LogFile(id, filePath, handle, st);
+    file.grantId = grantId;
+    file.fileSystem = this.fileSystem;
+    this.files.set(id, file);
+    file.startDriver();
+    return this.snapshot(file);
+  }
+
+  async openFile(filePath) {
+    if (!this.fileSystem) throw new ApiError("UNSUPPORTED", "host file API unavailable");
+    return this.openFileInternal(filePath);
+  }
+
+  async openDropped(p) {
+    if (!this.fileSystem) throw new ApiError("UNSUPPORTED", "dropped-file host API unavailable");
+    const filePath = String(p.path || "");
+    const grantId = String(p.grantId || "");
+    if (!filePath || !grantId) {
+      throw new ApiError("INVALID_ARGUMENT", "dropped file path and grant are required");
+    }
+    return this.openFileInternal(filePath, grantId);
+  }
+
+  snapshot(f) {
+    return {
+      fileId: f.id,
+      path: f.path,
+      name: path.basename(f.path),
+      size: f.rawSize,
+      epoch: f.epoch,
+      encoding: f.encoding,
+      totalLines: f.seqLines,
+      indexDone: f.seqDone,
+      stats: { ...f.stats },
+      follow: f.follow,
+    };
+  }
+
+  closeFile(p) {
+    const f = this.fileOf(p);
+    this.files.delete(f.id);
+    f.closed = true;
+    f.epoch += 1;
+    if (f.currentJob) f.currentJob.cancelled = true;
+    if (f.handle) void f.retireHandle(f.handle);
+    return { ok: true };
+  }
+
+  setFollow(p) {
+    const f = this.fileOf(p);
+    f.follow = Boolean(p.follow);
+    return { ok: true, follow: f.follow };
+  }
+
+  setEncoding(p) {
+    const f = this.fileOf(p);
+    const enc = String(p.encoding || "utf-8");
+    if (!ENCODINGS.has(enc)) {
+      throw new ApiError("INVALID_ARGUMENT", `encoding must be one of ${[...ENCODINGS].join("/")}`);
+    }
+    makeDecoder(enc); // validate early
+    f.encoding = enc;
+    return { ok: true, encoding: f.encoding };
+  }
+
+  statsOf(p) {
+    const f = this.fileOf(p);
+    return { fileId: f.id, stats: { ...f.stats }, indexDone: f.seqDone, totalLines: f.seqLines, size: f.rawSize };
+  }
+
+  // ---- paging -------------------------------------------------------------
+
+  /** Compile optional text filter; returns null or a per-line predicate. */
+  buildTextMatch(p) {
+    const filter = p && p.filter;
+    if (!filter || !String(filter.query || "").trim()) return null;
+    const matcher = this.buildMatcher(filter);
+    const invert = Boolean(filter.invert);
+    return (line) => (invert ? !matcher.test(line) : matcher.test(line));
+  }
+
+  async page(p) {
+    const f = this.fileOf(p);
+    const fromLine = Math.max(1, Math.floor(Number(p.fromLine) || 1));
+    const count = Math.min(2000, Math.max(1, Math.floor(Number(p.count) || 500)));
+    const levelFilter = normaliseLevelFilter(p.levels);
+    const textMatch = this.buildTextMatch(p);
+    const collect = [];
+    const result = await f.jumpScan({ fromLine, count, levelFilter, textMatch, collect, maxScanLines: MAX_PAGE_SCAN_LINES });
+    return {
+      fileId: f.id,
+      epoch: f.epoch,
+      lines: collect,
+      requested: fromLine,
+      eof: result.eof,
+      partial: result.partial,
+      scanned: result.scanned,
+      scanEndLine: result.nextLine,
+      hasMore: result.scanned >= MAX_PAGE_SCAN_LINES && collect.length >= count,
+      totalLines: f.seqLines,
+      indexDone: f.seqDone,
+      size: f.rawSize,
+      stats: { ...f.stats },
+    };
+  }
+
+  async poll(p) {
+    const f = this.fileOf(p);
+    const sinceLine = Math.max(0, Math.floor(Number(p.sinceLine) || 0));
+    let st = null;
+    try {
+      st = await f.handle.stat();
+    } catch {
+      return { fileId: f.id, epoch: f.epoch, missing: true };
+    }
+    let rotated = false;
+    const replaced =
+      st.size < f.rawSize ||
+      (f.ino && Number(st.ino) && Number(st.ino) !== f.ino) ||
+      (f.birthMs && st.birthtimeMs && Math.abs(st.birthtimeMs - f.birthMs) > 1500);
+    if (replaced) {
+      const handle = await this.openHandle(f.path, f.grantId).catch(() => null);
+      if (handle) {
+        const nst = await handle.stat();
+        await f.enqueue(async () => {
+          f.resetForReload(handle, nst);
+        });
+        rotated = true;
+      }
+    } else {
+      f.rawSize = st.size;
+      if (f.seqDone && st.size > f.readOffset) f.seqDone = false; // new data arrived
+    }
+    if (!f.seqDone) {
+      await f.enqueue(() => f.seqStep(POLL_CHUNK_BUDGET));
+    }
+    const totalLines = f.seqLines;
+    const events = [];
+    if (rotated) {
+      events.push({ type: "rotated", epoch: f.epoch });
+    } else if (sinceLine < totalLines) {
+      const fresh = f.ring.after(sinceLine);
+      if (fresh.length && fresh[0].no === sinceLine + 1) {
+        events.push({ type: "append", lines: fresh, totalLines });
+      } else {
+        events.push({ type: "catchup", totalLines });
+      }
+    }
+    return {
+      fileId: f.id,
+      epoch: f.epoch,
+      rotated,
+      events,
+      size: f.rawSize,
+      totalLines,
+      indexDone: f.seqDone,
+      stats: { ...f.stats },
+    };
+  }
+
+  // ---- search -------------------------------------------------------------
+
+  buildMatcher(p) {
+    const query = String(p.query || "");
+    try {
+      return compileQuery({ query, isRegex: Boolean(p.isRegex), caseSensitive: Boolean(p.caseSensitive) });
+    } catch (err) {
+      throw new ApiError("INVALID_ARGUMENT", err.message);
+    }
+  }
+
+  searchStart(p) {
+    const f = this.fileOf(p);
+    const matcher = this.buildMatcher(p);
+    if (f.currentJob && f.currentJob.status === "running") f.currentJob.status = "cancelled";
+    const job = {
+      id: this.nextJobId++,
+      file: f,
+      status: "running",
+      matcher,
+      scannedBytes: 0,
+      matchCount: 0,
+      matches: [],
+      error: null,
+      cancelled: false,
+    };
+    this.jobs.set(job.id, job);
+    f.currentJob = job;
+    this.pruneJobs();
+    (async () => {
+      const token = f.acquireRead();
+      try {
+        let offset = 0;
+        let lineNo = 1;
+        let pending = null;
+        let pendingLen = 0;
+        const decoder = makeDecoder(f.encoding);
+        while (!job.cancelled) {
+          if (f.isStale(token)) {
+            job.status = "cancelled";
+            return;
+          }
+          const buffer = Buffer.allocUnsafe(CHUNK_BYTES);
+          const { bytesRead } = await token.handle.read(buffer, 0, CHUNK_BYTES, offset);
+          if (bytesRead === 0) {
+            if (pendingLen && pending) {
+              this.searchLine(job, clipLine(decoder.decode(pending)), lineNo);
+              lineNo += 1;
+            }
+            break;
+          }
+          let buf = buffer.subarray(0, bytesRead);
+          if (pendingLen) buf = Buffer.concat([pending, buf]);
+          const bufStart = offset - pendingLen;
+          offset += bytesRead;
+          const lastNl = buf.lastIndexOf(0x0a);
+          if (lastNl === -1) {
+            if (bytesRead < CHUNK_BYTES) {
+              this.searchLine(job, clipLine(decoder.decode(buf)), lineNo);
+              lineNo += 1;
+              pending = null;
+              pendingLen = 0;
+              break;
+            }
+            if (buf.length > MAX_PENDING_BYTES) {
+              this.searchLine(job, clipLine(decoder.decode(buf)), lineNo);
+              lineNo += 1;
+              pending = null;
+              pendingLen = 0;
+            } else {
+              pending = Buffer.from(buf);
+              pendingLen = buf.length;
+            }
+            continue;
+          }
+          const region = buf.subarray(0, lastNl + 1);
+          const parts = decoder.decode(region).split("\n");
+          parts.pop();
+          for (let i = 0; i < parts.length; i += 1) {
+            let line = parts[i];
+            if (line.endsWith("\r")) line = line.slice(0, -1);
+            this.searchLine(job, clipLine(line), lineNo);
+            lineNo += 1;
+          }
+          job.scannedBytes = bufStart + lastNl + 1;
+          const rest = buf.subarray(lastNl + 1);
+          pending = rest.length ? Buffer.from(rest) : null;
+          pendingLen = rest.length;
+          await new Promise((resolve) => setImmediate(resolve));
+        }
+        job.status = job.cancelled ? "cancelled" : "done";
+      } catch (err) {
+        job.status = "error";
+        job.error = err.message;
+      } finally {
+        f.releaseRead(token);
+      }
+    })();
+    return { jobId: job.id };
+  }
+
+  searchLine(job, line, lineNo) {
+    if (job.matcher.test(line)) {
+      job.matchCount += 1;
+      if (job.matches.length < MAX_STORED_MATCHES) {
+        job.matches.push({ line: lineNo, text: line.length > 300 ? line.slice(0, 300) : line });
+      }
+    }
+  }
+
+  pruneJobs() {
+    if (this.jobs.size <= MAX_JOBS) return;
+    const done = [...this.jobs.values()].filter((j) => j.status !== "running").sort((a, b) => a.id - b.id);
+    for (const j of done) {
+      if (this.jobs.size <= MAX_JOBS) break;
+      this.jobs.delete(j.id);
+    }
+  }
+
+  jobOf(p) {
+    const id = Number(p && p.jobId);
+    const job = this.jobs.get(id);
+    if (!job) throw new ApiError("NOT_FOUND", "job not found");
+    return job;
+  }
+
+  searchStatus(p) {
+    const job = this.jobOf(p);
+    return {
+      jobId: job.id,
+      status: job.status,
+      scannedBytes: job.scannedBytes,
+      fileSize: job.file.rawSize,
+      matchCount: job.matchCount,
+      storedMatches: job.matches.length,
+      error: job.error,
+    };
+  }
+
+  searchMatches(p) {
+    const job = this.jobOf(p);
+    const offset = Math.max(0, Math.floor(Number(p.offset) || 0));
+    const limit = Math.min(500, Math.max(1, Math.floor(Number(p.limit) || 100)));
+    return {
+      jobId: job.id,
+      matches: job.matches.slice(offset, offset + limit),
+      matchCount: job.matchCount,
+      stored: job.matches.length,
+      status: job.status,
+    };
+  }
+
+  searchCancel(p) {
+    const job = this.jobOf(p);
+    if (job.status === "running") job.cancelled = true;
+    return { ok: true, status: job.status };
+  }
+
+  // ---- persisted state ----------------------------------------------------
+
+  stateFile() {
+    return this.dataPath ? path.join(this.dataPath, "state.json") : null;
+  }
+
+  async saveState(p) {
+    const file = this.stateFile();
+    if (!file) return { ok: false };
+    try {
+      await fsp.mkdir(this.dataPath, { recursive: true });
+      const tabs = Array.isArray(p.tabs) ? p.tabs.slice(0, MAX_OPEN_FILES) : [];
+      const slim = tabs.map((t) => ({
+        path: t.path ? String(t.path) : null,
+        name: String(t.name || ""),
+        size: Number(t.size) || 0,
+        line: Math.max(1, Math.floor(Number(t.line) || 1)),
+        encoding: ENCODINGS.has(t.encoding) ? t.encoding : "utf-8",
+        follow: Boolean(t.follow),
+        levels: Array.isArray(t.levels) ? t.levels.map(String) : [],
+        excludeLevels: Array.isArray(t.excludeLevels) ? t.excludeLevels.map(String) : [],
+        mode: t.mode === "drop" ? "drop" : "native",
+        filterQuery: t.filterQuery ? String(t.filterQuery) : "",
+        filterIsRegex: Boolean(t.filterIsRegex),
+        filterCaseSensitive: Boolean(t.filterCaseSensitive),
+        filterInvert: Boolean(t.filterInvert),
+      }));
+      await fsp.writeFile(
+        file,
+        JSON.stringify({ version: 1, active: Math.floor(Number(p.active) || 0), tabs: slim }, null, 2),
+        "utf-8",
+      );
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err.message };
+    }
+  }
+
+  async restoreState() {
+    const file = this.stateFile();
+    if (!file) return { tabs: [], active: 0 };
+    let data;
+    try {
+      data = JSON.parse(await fsp.readFile(file, "utf-8"));
+    } catch {
+      return { tabs: [], active: 0 };
+    }
+    const tabs = [];
+    for (const t of Array.isArray(data.tabs) ? data.tabs : []) {
+      if (t.mode === "drop" || !t.path) {
+        tabs.push({ ...t, restorable: false });
+        continue;
+      }
+      try {
+        // Restore uses the path the user already picked last session; the
+        // grant root may not be set yet on panel boot.
+        const opened = await this.openFileInternal(t.path);
+        if (t.encoding) await this.setEncoding({ fileId: opened.fileId, encoding: t.encoding });
+        if (t.follow) await this.setFollow({ fileId: opened.fileId, follow: true });
+        tabs.push({ ...t, restorable: true, fileId: opened.fileId, size: opened.size });
+      } catch {
+        tabs.push({ ...t, restorable: false });
+      }
+    }
+    return { tabs, active: Math.floor(Number(data.active) || 0) };
+  }
+
+  // ---- lifecycle ----------------------------------------------------------
+
+  dispose() {
+    for (const f of this.files.values()) {
+      f.closed = true;
+      f.epoch += 1;
+      if (f.currentJob) f.currentJob.cancelled = true;
+      if (f.handle) void f.retireHandle(f.handle);
+    }
+    this.files.clear();
+    for (const j of this.jobs.values()) j.cancelled = true;
+    this.jobs.clear();
+  }
+}
+
+module.exports = { LogEngine, ApiError, ENCODINGS, createHostFileSystem };

--- a/plugins/pi.log-viewer/main.js
+++ b/plugins/pi.log-viewer/main.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const path = require("node:path");
+const { LogEngine, createHostFileSystem } = require("./lib/log-engine.js");
+
+const COMMAND_ID = "log-viewer.open";
+let engine = null;
+
+function detectCapabilities() {
+  let readRange = false;
+  let stat = false;
+  try {
+    readRange = typeof pi !== "undefined" && pi.fs && typeof pi.fs.readRange === "function";
+    stat = typeof pi !== "undefined" && pi.fs && typeof pi.fs.stat === "function";
+  } catch {
+    // pi global unavailable during early load
+  }
+  return { hostReadRange: readRange, hostStat: stat };
+}
+
+async function onLoad() {
+  const capabilities = detectCapabilities();
+  if (!capabilities.hostReadRange || !capabilities.hostStat) {
+    throw new Error("PI-Desktop fs.stat and fs.readRange APIs are required");
+  }
+  let dataPath = null;
+  try {
+    dataPath = await pi.plugin.getDataPath();
+  } catch {
+    dataPath = null; // state memory disabled without a data path
+  }
+  engine = new LogEngine({
+    dataPath,
+    capabilities,
+    fileSystem: createHostFileSystem(pi.fs),
+  });
+  await pi.commands.register({
+    id: COMMAND_ID,
+    title: "日志查看器：打开",
+    keywords: ["log", "日志", "viewer", "tail"],
+    run: async () => {
+      // 面板标题由 manifest.ui.title 双语字段提供，不要在此覆盖
+      await pi.ui.openPanel();
+    },
+  });
+}
+
+async function onUnload() {
+  try {
+    await pi.commands.unregister(COMMAND_ID);
+  } catch {
+    // already gone
+  }
+  if (engine) {
+    engine.dispose();
+    engine = null;
+  }
+}
+
+async function onPanelInvoke(channel, payload) {
+  if (!engine) throw new Error("engine not ready");
+  const op = String(channel || "").replace(/^engine\./, "");
+  return engine.handle(op, payload || {});
+}
+
+module.exports = { onLoad, onUnload, onPanelInvoke };

--- a/plugins/pi.log-viewer/manifest.json
+++ b/plugins/pi.log-viewer/manifest.json
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": 1,
+  "id": "pi.log-viewer",
+  "name": "日志查看器",
+  "version": "0.2.0",
+  "description": "PI-Desktop 大日志文件查看器：GB 级流式分页与虚拟滚动、实时跟随、搜索高亮、文本/等级过滤、钉住对比、多文件页签。",
+  "i18n": {
+    "en": {
+      "name": "Log Viewer",
+      "description": "PI-Desktop log viewer for huge files: streamed paging with virtual scroll, tail follow, search highlight, text/level filter, pinned lines, and multi-file tabs.",
+      "safetyNotes": "Reads only user-selected .log/.txt files through the host fs.read permission gateway (stat/readRange). No writes, no network. Session grants are memory-only; dropped/picked file grants expire with the process. Plugin state (tabs, filters, level colors) is stored in the plugin data directory."
+    },
+    "zh-CN": {
+      "name": "日志查看器",
+      "description": "PI-Desktop 大日志文件查看器：GB 级流式分页与虚拟滚动、实时跟随、搜索高亮、文本/等级过滤、钉住对比、多文件页签。",
+      "safetyNotes": "仅通过宿主 fs.read 权限网关（stat/readRange）只读访问用户选定的 .log/.txt 文件；不写入、不联网。目录与拖入授权仅存内存、随进程失效。页签/过滤/等级配色等状态保存在插件数据目录。"
+    }
+  },
+  "author": "Tioit-Wang",
+  "categories": ["developer-tools", "productivity"],
+  "changelog": "Release 0.2.0：插件 id 定稿 pi.log-viewer；搜索与文本过滤分离（搜索高亮可跳转，过滤只显示/隐藏命中）；过滤视图虚拟滚动；等级配色设置；钉住最多 5 行对比；右键「清除筛选并跳转」；系统文件选择器打开 .log/.txt；首次打开示例引导日志；修复静态文件误报新增、顶部首行窗口空白与底部留白。",
+  "safetyNotes": "仅通过宿主 fs.read 权限网关只读访问用户选定的日志文件；不写入、不联网。目录与拖入/选择文件授权仅存内存、随进程失效。页签/过滤/等级配色等状态保存在插件数据目录。",
+  "main": "main.js",
+  "ui": {
+    "panel": "renderer/index.html",
+    "title": {
+      "en": "Log Viewer",
+      "zh-CN": "日志查看器"
+    },
+    "width": 1280,
+    "height": 832
+  },
+  "contributes": {
+    "commands": [
+      {
+        "id": "log-viewer.open",
+        "title": "日志查看器：打开",
+        "keywords": ["log", "日志", "viewer", "tail", "filter"],
+        "category": "Developer Tools"
+      }
+    ]
+  },
+  "permissions": ["ui.panel", "fs.read", "clipboard.write"],
+  "fs": {
+    "read": { "root": "userSelected" }
+  },
+  "engines": {
+    "piDesktop": ">=0.14.3"
+  },
+  "activationEvents": [
+    "onCommand:log-viewer.open"
+  ]
+}

--- a/plugins/pi.log-viewer/renderer/app.js
+++ b/plugins/pi.log-viewer/renderer/app.js
@@ -1,0 +1,2115 @@
+"use strict";
+
+/* Large log viewer — panel UI. All file reads go through the host fs gateway. */
+
+const bridge = window.pluginBridge;
+const $ = (id) => document.getElementById(id);
+
+const OVERSCAN = 10;
+const MAX_PINS = 5;
+const LEVEL_KEYS = ["error", "warn", "info", "debug"];
+const DEFAULT_LEVEL_COLORS = {
+  // light / dark defaults as hex; applied as CSS RGB triples
+  light: {
+    error: { bg: "#c93c42", fg: "#c93c42" },
+    warn: { bg: "#b45309", fg: "#b45309" },
+    info: { bg: "#3d6b8f", fg: "#2e2c29" },
+    debug: { bg: "#9b958a", fg: "#6f6a61" },
+  },
+  dark: {
+    error: { bg: "#e5484d", fg: "#e5484d" },
+    warn: { bg: "#f0a030", fg: "#f0a030" },
+    info: { bg: "#78a0c8", fg: "#f2f2f2" },
+    debug: { bg: "#737373", fg: "#a6a6a6" },
+  },
+};
+const state = {
+  tabs: [],
+  activeId: null,
+  nextTabId: 1,
+  fontSize: Number(localStorage.getItem("lv.fontSize")) || 12,
+  fontFamily: localStorage.getItem("lv.fontFamily") || "default",
+  theme: localStorage.getItem("lv.theme") || null, // null → follow host; "light" 米白 / "dark" 黑夜
+  levelColors: loadLevelColors(),
+};
+let rowH = 20;
+
+const SVG_SUN = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></svg>';
+const SVG_MOON = '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><path d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z"/></svg>';
+
+const scroller = $("scroller");
+const spacer = $("spacer");
+
+// ---------- small utils ------------------------------------------------------
+
+function fmtSize(n) {
+  if (!Number.isFinite(n)) return "—";
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(2)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+function fmtTime(ms) {
+  if (!Number.isFinite(ms) || !ms) return "";
+  const d = new Date(ms);
+  const p = (x) => String(x).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+let toastTimer = null;
+function toast(msg) {
+  const el = $("toast");
+  el.textContent = msg;
+  el.classList.add("show");
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => el.classList.remove("show"), 2400);
+}
+
+function invoke(channel, payload) {
+  return bridge.invoke(channel, payload);
+}
+
+// ---------- level colors -----------------------------------------------------
+
+function hexToRgbTriple(hex) {
+  const m = /^#?([0-9a-f]{6})$/i.exec(String(hex || "").trim());
+  if (!m) return null;
+  const n = parseInt(m[1], 16);
+  return `${(n >> 16) & 255} ${(n >> 8) & 255} ${n & 255}`;
+}
+
+function loadLevelColors() {
+  try {
+    const raw = localStorage.getItem("lv.levelColors");
+    if (!raw) return { light: null, dark: null };
+    const parsed = JSON.parse(raw);
+    return {
+      light: parsed && parsed.light ? parsed.light : null,
+      dark: parsed && parsed.dark ? parsed.dark : null,
+    };
+  } catch {
+    return { light: null, dark: null };
+  }
+}
+
+function saveLevelColors() {
+  localStorage.setItem("lv.levelColors", JSON.stringify(state.levelColors));
+}
+
+function resolveLevelColors(themeName) {
+  const base = DEFAULT_LEVEL_COLORS[themeName] || DEFAULT_LEVEL_COLORS.light;
+  const custom = state.levelColors[themeName] || {};
+  const out = {};
+  for (const lv of LEVEL_KEYS) {
+    out[lv] = {
+      bg: (custom[lv] && custom[lv].bg) || base[lv].bg,
+      fg: (custom[lv] && custom[lv].fg) || base[lv].fg,
+    };
+  }
+  return out;
+}
+
+function applyLevelColors(themeName) {
+  const colors = resolveLevelColors(themeName);
+  const root = document.documentElement;
+  for (const lv of LEVEL_KEYS) {
+    const bg = hexToRgbTriple(colors[lv].bg);
+    const fg = hexToRgbTriple(colors[lv].fg);
+    if (bg) root.style.setProperty(`--lv-${lv}-bg`, bg);
+    if (fg) root.style.setProperty(`--lv-${lv}-fg`, fg);
+  }
+}
+
+function openSettings() {
+  const themeName = document.documentElement.dataset.theme === "light" ? "light" : "dark";
+  const colors = resolveLevelColors(themeName);
+  const map = {
+    error: ["clrErrorBg", "clrErrorFg"],
+    warn: ["clrWarnBg", "clrWarnFg"],
+    info: ["clrInfoBg", "clrInfoFg"],
+    debug: ["clrDebugBg", "clrDebugFg"],
+  };
+  for (const lv of LEVEL_KEYS) {
+    const [bgId, fgId] = map[lv];
+    $(bgId).value = colors[lv].bg;
+    $(fgId).value = colors[lv].fg;
+  }
+  $("settingsHint").textContent = themeName === "light" ? "当前主题：米白" : "当前主题：黑夜";
+  $("settingsOverlay").classList.add("show");
+}
+
+function closeSettings() {
+  $("settingsOverlay").classList.remove("show");
+}
+
+function bindSettingsColorInputs() {
+  const map = {
+    error: ["clrErrorBg", "clrErrorFg"],
+    warn: ["clrWarnBg", "clrWarnFg"],
+    info: ["clrInfoBg", "clrInfoFg"],
+    debug: ["clrDebugBg", "clrDebugFg"],
+  };
+  const themeName = () => (document.documentElement.dataset.theme === "light" ? "light" : "dark");
+  for (const lv of LEVEL_KEYS) {
+    const [bgId, fgId] = map[lv];
+    $(bgId).addEventListener("input", () => {
+      const t = themeName();
+      if (!state.levelColors[t]) state.levelColors[t] = {};
+      if (!state.levelColors[t][lv]) state.levelColors[t][lv] = {};
+      state.levelColors[t][lv].bg = $(bgId).value;
+      saveLevelColors();
+      applyLevelColors(t);
+      const tab = activeTab();
+      if (tab) {
+        if (hasViewFilter(tab)) {
+          tab._fpaintKey = null;
+          renderFilteredViewport(tab);
+        } else if (tab.window) {
+          paintRows(tab, tab.window.lines, { absolute: true });
+        }
+      }
+    });
+    $(fgId).addEventListener("input", () => {
+      const t = themeName();
+      if (!state.levelColors[t]) state.levelColors[t] = {};
+      if (!state.levelColors[t][lv]) state.levelColors[t][lv] = {};
+      state.levelColors[t][lv].fg = $(fgId).value;
+      saveLevelColors();
+      applyLevelColors(t);
+      const tab = activeTab();
+      if (tab) {
+        if (hasViewFilter(tab)) {
+          tab._fpaintKey = null;
+          renderFilteredViewport(tab);
+        } else if (tab.window) {
+          paintRows(tab, tab.window.lines, { absolute: true });
+        }
+      }
+    });
+  }
+  $("settingsReset").addEventListener("click", () => {
+    const t = themeName();
+    state.levelColors[t] = null;
+    saveLevelColors();
+    applyLevelColors(t);
+    openSettings(); // refresh pickers
+    const tab = activeTab();
+    if (tab) {
+      if (hasViewFilter(tab)) {
+        tab._fpaintKey = null;
+        renderFilteredViewport(tab);
+      } else if (tab.window) {
+        paintRows(tab, tab.window.lines, { absolute: true });
+      }
+    }
+  });
+  $("settingsDone").addEventListener("click", closeSettings);
+  $("settingsClose").addEventListener("click", closeSettings);
+  $("settingsOverlay").addEventListener("click", (e) => {
+    if (e.target === $("settingsOverlay")) closeSettings();
+  });
+}
+
+function rememberPreFilterScroll(tab) {
+  if (!tab || hasViewFilter(tab)) return;
+  tab.preFilterLine = Math.max(1, lineAtScroll());
+}
+
+/** Leave filtered feed: rebuild spacer at full height, then paint unfiltered window. */
+function exitToUnfilteredView(tab) {
+  if (!tab) return;
+  const target = Math.max(1, tab.preFilterLine || tab.viewLine || tab.lastLine || 1);
+  tab.feedRows = [];
+  tab.feedCount = 0;
+  tab.feedFrom = 1;
+  tab.filterEof = false;
+  tab.loadingMore = false;
+  tab._fpaintKey = null;
+  tab.window = null;
+  updateSpacer(tab);
+  const maxLine = Math.max(tab.totalLines, 1);
+  const line = tab.indexDone ? Math.min(target, maxLine) : Math.max(1, target);
+  tab.viewLine = line;
+  scroller.scrollTop = Math.max(0, (line - 1) * rowH);
+  renderWindow(tab, line);
+  updateStatus(tab);
+}
+
+function activeTab() {
+  return state.tabs.find((t) => t.id === state.activeId) || null;
+}
+
+function hasLevelFilter(tab) {
+  return Boolean(tab && ((tab.levels && tab.levels.size) || (tab.excludedLevels && tab.excludedLevels.size)));
+}
+
+function hasTextFilter(tab) {
+  return Boolean(tab && tab.filter && String(tab.filter.query || "").trim());
+}
+
+/** Level badges and/or text filter: the sequential "filtered feed" view. */
+function hasViewFilter(tab) {
+  return hasLevelFilter(tab) || hasTextFilter(tab);
+}
+
+function levelFilterPayload(tab) {
+  if (!hasLevelFilter(tab)) return null;
+  return {
+    include: tab.levels ? [...tab.levels] : [],
+    exclude: tab.excludedLevels ? [...tab.excludedLevels] : [],
+  };
+}
+
+function textFilterPayload(tab) {
+  if (!hasTextFilter(tab)) return null;
+  const f = tab.filter;
+  return {
+    query: f.query,
+    isRegex: Boolean(f.isRegex),
+    caseSensitive: Boolean(f.caseSensitive),
+    invert: Boolean(f.invert),
+  };
+}
+
+function pageFilters(tab) {
+  return { levels: levelFilterPayload(tab), filter: textFilterPayload(tab) };
+}
+
+function badgeState(tab, level) {
+  if (tab && tab.levels && tab.levels.has(level)) return "include";
+  if (tab && tab.excludedLevels && tab.excludedLevels.has(level)) return "exclude";
+  return "neutral";
+}
+
+function atBottom() {
+  return scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 2;
+}
+
+// ---------- adapters ---------------------------------------------------------
+
+/** 首次打开的虚拟引导日志（纯内存，不落盘、不写入会话状态）。 */
+const DEMO_LOG_LINES = [
+  "# ── 日志查看器 · 使用引导 ──────────────────────────────",
+  "# 这是一份虚拟示例日志，不会写入磁盘。打开真实 .log / .txt 后可关闭本页签。",
+  "#",
+  "# 推荐格式：时间|等级|模块|消息   （与常见 Python / 自研服务日志一致）",
+  "# 也支持：[2026-01-01 10:00:00] [ERROR] app - message",
+  "#          2026-01-01 10:00:00 ERROR message",
+  "#",
+  "# 快捷上手：",
+  "#   · 点击右侧 ERROR / WARN / INFO / DEBUG 徽章 → 等级过滤（再点循环：包含→排除→取消）",
+  "#   · 工具栏放大镜 → 搜索栏：全文高亮，F3 / Shift+F3 跳转（不隐藏其它行）",
+  "#   · 工具栏漏斗 → 过滤栏：只显示匹配行，可勾选「隐藏匹配」反向",
+  "#   · Ctrl+G 跳转行号；点击行号复制整行；右键复制选中",
+  "#   · 「实时跟随」追新写入的增长日志（静态文件无需开启）",
+  "# ────────────────────────────────────────────────────────────",
+  "",
+  "2026-01-08 09:00:01|INFO|bootstrap|service starting, env=prod version=2.4.1",
+  "2026-01-08 09:00:01|INFO|bootstrap|config loaded from /etc/app/config.yaml",
+  "2026-01-08 09:00:02|DEBUG|bootstrap|feature flags: cache=true, tracing=false",
+  "2026-01-08 09:00:02|INFO|db|connecting to postgres host=db-primary:5432",
+  "2026-01-08 09:00:02|INFO|db|connection pool ready size=10",
+  "2026-01-08 09:00:03|INFO|http|listening on 0.0.0.0:8080",
+  "2026-01-08 09:00:10|INFO|http|GET /health 200 2ms",
+  "2026-01-08 09:00:12|INFO|http|GET /api/users?page=1 200 18ms",
+  "2026-01-08 09:00:15|WARN|cache|redis latency high rtt=120ms threshold=100ms",
+  "2026-01-08 09:00:18|INFO|http|POST /api/login 200 45ms user_id=10086",
+  "2026-01-08 09:00:22|DEBUG|auth|jwt issued sub=10086 exp=+3600s",
+  "2026-01-08 09:00:30|INFO|worker|job queued id=job_9f3a type=email",
+  "2026-01-08 09:00:31|INFO|worker|job started id=job_9f3a",
+  "2026-01-08 09:00:33|WARN|worker|smtp slow response, retrying attempt=1",
+  "2026-01-08 09:00:35|ERROR|worker|job failed id=job_9f3a error=smtp timeout after 3 retries",
+  "2026-01-08 09:00:35|DEBUG|worker|stack: TimeoutError: smtp timeout",
+  "2026-01-08 09:00:35|DEBUG|worker|    at SmtpClient.send (smtp.js:128)",
+  "2026-01-08 09:00:35|DEBUG|worker|    at EmailJob.run (jobs/email.js:56)",
+  "2026-01-08 09:00:40|INFO|http|GET /api/orders 200 32ms",
+  "2026-01-08 09:00:45|WARN|db|slow query duration=850ms sql=SELECT * FROM orders WHERE status='open'",
+  "2026-01-08 09:00:50|INFO|http|GET /metrics 200 5ms",
+  "2026-01-08 09:01:00|INFO|scheduler|heartbeat ok, queue_depth=3",
+  "2026-01-08 09:01:05|ERROR|http|GET /api/report 500 1200ms error=division by zero",
+  "2026-01-08 09:01:05|INFO|http|request_id=req_7c2e marked failed",
+  "2026-01-08 09:01:10|INFO|http|GET /api/users?page=2 200 21ms",
+  "2026-01-08 09:01:15|DEBUG|cache|hit key=user:10086 ttl_left=280s",
+  "2026-01-08 09:01:20|WARN|http|rate limit near threshold ip=10.0.0.12 used=92%",
+  "2026-01-08 09:01:25|INFO|db|checkpoint complete wal=000000010000000000000042",
+  "2026-01-08 09:01:30|ERROR|db|connection reset by peer host=db-primary:5432",
+  "2026-01-08 09:01:30|INFO|db|reconnecting attempt=1",
+  "2026-01-08 09:01:31|INFO|db|connection restored",
+  "2026-01-08 09:01:40|INFO|http|GET /health 200 1ms",
+  "2026-01-08 09:01:45|TRACE|http|upstream call trace_id=abc123 span=db.query",
+  "2026-01-08 09:01:50|INFO|worker|job succeeded id=job_a1b2 type=email",
+  "2026-01-08 09:01:55|WARN|disk|usage 81% path=/var/log",
+  "2026-01-08 09:02:00|INFO|scheduler|heartbeat ok, queue_depth=1",
+  "2026-01-08 09:02:05|ERROR|payment|charge declined order=ord_5512 reason=insufficient_funds",
+  "2026-01-08 09:02:05|INFO|payment|notified user_id=20001 channel=inapp",
+  "2026-01-08 09:02:10|DEBUG|http|query plan: Index Scan using users_pkey",
+  "2026-01-08 09:02:15|INFO|http|PUT /api/users/10086 200 28ms",
+  "2026-01-08 09:02:20|WARN|cache|evicted 12 keys reason=maxmemory",
+  "2026-01-08 09:02:25|INFO|http|GET /api/orders 200 24ms",
+  "2026-01-08 09:02:30|FATAL|bootstrap|simulated crash — 在真实日志中 FATAL 会归入 ERROR 等级",
+  "2026-01-08 09:02:31|INFO|bootstrap|（示例结束）试着：点 ERROR 徽章只看错误；或在过滤栏输入 timeout / job_",
+  "2026-01-08 09:02:32|INFO|bootstrap|搜索栏输入 connection 可高亮命中；F3 循环跳到下一处",
+];
+
+function computeDemoStats(lines) {
+  const stats = { error: 0, warn: 0, info: 0, debug: 0 };
+  for (const line of lines) {
+    const lv = LogLevel.levelFromLine(line);
+    if (lv && lv !== "other" && stats[lv] != null) stats[lv] += 1;
+  }
+  return stats;
+}
+
+function demoMatchesFilters(line, { levels, filter }) {
+  if (levels) {
+    const lv = LogLevel.levelFromLine(line);
+    const include = new Set(levels.include || []);
+    const exclude = new Set(levels.exclude || []);
+    if (exclude.has(lv)) return false;
+    if (include.size && !include.has(lv)) return false;
+  }
+  if (filter && filter.query) {
+    try {
+      const matcher = LogQuery.compileQuery({
+        query: filter.query,
+        isRegex: Boolean(filter.isRegex),
+        caseSensitive: Boolean(filter.caseSensitive),
+      });
+      const hit = matcher.test(line);
+      if (filter.invert ? hit : !hit) return false;
+    } catch {
+      return true; // 非法查询时不过滤，避免空白
+    }
+  }
+  return true;
+}
+
+function createDemoAdapter() {
+  const lines = DEMO_LOG_LINES.slice();
+  const stats = computeDemoStats(lines);
+  const size = lines.reduce((n, l) => n + l.length + 1, 0);
+  let jobId = 1;
+  const jobs = new Map();
+  const snapshot = () => ({
+    totalLines: lines.length,
+    indexDone: true,
+    size,
+    stats: { ...stats },
+  });
+
+  return {
+    mode: "demo",
+    page: async (p) => {
+      const from = Math.max(1, Math.floor(Number(p.fromLine) || 1));
+      const count = Math.min(2000, Math.max(1, Math.floor(Number(p.count) || 500)));
+      const filters = { levels: p.levels || null, filter: p.filter || null };
+      const out = [];
+      let scanned = 0;
+      let next = from;
+      for (let i = from - 1; i < lines.length && out.length < count; i += 1) {
+        scanned += 1;
+        next = i + 2;
+        const text = lines[i];
+        if (demoMatchesFilters(text, filters)) out.push({ no: i + 1, text });
+      }
+      const eof = next > lines.length;
+      return {
+        fileId: 0,
+        epoch: 1,
+        lines: out,
+        requested: from,
+        eof,
+        partial: null,
+        scanned,
+        scanEndLine: next,
+        hasMore: false,
+        ...snapshot(),
+      };
+    },
+    poll: async () => ({ fileId: 0, epoch: 1, rotated: false, events: [], missing: false, ...snapshot() }),
+    setFollow: async (p) => ({ ok: true, follow: Boolean(p && p.follow) }),
+    setEncoding: async (p) => ({ ok: true, encoding: (p && p.encoding) || "utf-8" }),
+    stats: async () => ({ fileId: 0, ...snapshot() }),
+    searchStart: (p) => {
+      const id = jobId++;
+      const query = String((p && p.query) || "");
+      const isRegex = Boolean(p && p.isRegex);
+      const caseSensitive = Boolean(p && p.caseSensitive);
+      const matches = [];
+      let matchCount = 0;
+      let error = null;
+      try {
+        const matcher = LogQuery.compileQuery({ query, isRegex, caseSensitive });
+        lines.forEach((text, idx) => {
+          if (matcher.test(text)) {
+            matchCount += 1;
+            if (matches.length < 5000) {
+              matches.push({ line: idx + 1, text: text.length > 300 ? text.slice(0, 300) : text });
+            }
+          }
+        });
+      } catch (err) {
+        error = err.message || String(err);
+      }
+      jobs.set(id, { status: error ? "error" : "done", matchCount, matches, error });
+      return Promise.resolve({ jobId: id });
+    },
+    searchStatus: async (p) => {
+      const job = jobs.get(Number(p && p.jobId));
+      if (!job) return { status: "error", error: "job not found", matchCount: 0, storedMatches: 0 };
+      return {
+        jobId: Number(p.jobId),
+        status: job.status,
+        scannedBytes: size,
+        fileSize: size,
+        matchCount: job.matchCount,
+        storedMatches: job.matches.length,
+        error: job.error,
+      };
+    },
+    searchMatches: async (p) => {
+      const job = jobs.get(Number(p && p.jobId));
+      if (!job) return { matches: [], matchCount: 0, stored: 0, status: "error" };
+      const offset = Math.max(0, Number(p.offset) || 0);
+      const limit = Math.min(500, Math.max(1, Number(p.limit) || 100));
+      return {
+        jobId: Number(p.jobId),
+        matches: job.matches.slice(offset, offset + limit),
+        matchCount: job.matchCount,
+        stored: job.matches.length,
+        status: job.status,
+      };
+    },
+    searchCancel: async (p) => {
+      const job = jobs.get(Number(p && p.jobId));
+      if (job) job.status = "cancelled";
+      return { ok: true, status: job ? job.status : "cancelled" };
+    },
+    close: async () => ({ ok: true }),
+  };
+}
+
+function createNativeAdapter() {
+  const call = (op, payload) => invoke(`engine.${op}`, payload);
+  return {
+    mode: "native",
+    open: (path) => call("openFile", { path }),
+    listDir: (path) => call("listDir", { path }),
+    setRoot: (path) => call("setRoot", { path }),
+    page: (p) => call("page", p),
+    poll: (p) => call("poll", p),
+    setFollow: (p) => call("setFollow", p),
+    setEncoding: (p) => call("setEncoding", p),
+    stats: (p) => call("stats", p),
+    searchStart: (p) => call("searchStart", p),
+    searchStatus: (p) => call("searchStatus", p),
+    searchMatches: (p) => call("searchMatches", p),
+    searchCancel: (p) => call("searchCancel", p),
+    close: (p) => call("close", p),
+  };
+}
+
+// ---------- tabs -------------------------------------------------------------
+
+function createTab({ mode, name, path, adapter, saved }) {
+  const tab = {
+    id: state.nextTabId++,
+    mode,
+    name: name || "未命名",
+    path: path || null,
+    size: (saved && saved.size) || 0,
+    seenSize: (saved && saved.size) || 0,
+    encoding: (saved && saved.encoding) || "utf-8",
+    follow: Boolean(saved && saved.follow),
+    levels: saved && Array.isArray(saved.levels) && saved.levels.length ? new Set(saved.levels) : null,
+    excludedLevels:
+      saved && Array.isArray(saved.excludeLevels) && saved.excludeLevels.length ? new Set(saved.excludeLevels) : null,
+    filter:
+      saved && saved.filterQuery
+        ? {
+            query: String(saved.filterQuery),
+            isRegex: Boolean(saved.filterIsRegex),
+            caseSensitive: Boolean(saved.filterCaseSensitive),
+            invert: Boolean(saved.filterInvert),
+          }
+        : null,
+    lastLine: (saved && saved.line) || 1,
+    /** 浏览位置（视口首行）；lastLine 仅作轮询游标，打开静态文件时两者分离。 */
+    viewLine: Math.max(1, (saved && saved.line) || 1),
+    totalLines: 0,
+    indexDone: false,
+    stats: { error: 0, warn: 0, info: 0, debug: 0 },
+    search: null,
+    adapter,
+    renderToken: 0,
+    window: null, // { from, to, lines }
+    feedFrom: 1,
+    feedCount: 0,
+    tailSeen: 0,
+    error: null,
+    pins: [], // [{ no, text }] 最多 MAX_PINS 条
+  };
+  state.tabs.push(tab);
+  renderTabs();
+  return tab;
+}
+
+function closeTab(id) {
+  const idx = state.tabs.findIndex((t) => t.id === id);
+  if (idx === -1) return;
+  const tab = state.tabs[idx];
+  try {
+    tab.adapter.close({ fileId: tab.fileId });
+  } catch {
+    // best effort
+  }
+  state.tabs.splice(idx, 1);
+  if (state.activeId === id) {
+    const next = state.tabs[Math.max(0, idx - 1)];
+    state.activeId = next ? next.id : null;
+  }
+  renderTabs();
+  activateView();
+  scheduleSaveState();
+}
+
+function activateTab(id) {
+  state.activeId = id;
+  renderTabs();
+  activateView();
+  scheduleSaveState();
+}
+
+function renderTabs() {
+  const box = $("tabs");
+  box.textContent = "";
+  for (const tab of state.tabs) {
+    const el = document.createElement("div");
+    el.className = `tab${tab.id === state.activeId ? " active" : ""}`;
+    const name = document.createElement("span");
+    name.className = "t-name";
+    name.textContent = tab.name;
+    name.title = tab.path || tab.name;
+    const close = document.createElement("button");
+    close.className = "t-close";
+    close.textContent = "✕";
+    close.title = "关闭";
+    close.addEventListener("click", (e) => {
+      e.stopPropagation();
+      closeTab(tab.id);
+    });
+    el.append(name, close);
+    el.addEventListener("click", () => activateTab(tab.id));
+    box.append(el);
+  }
+  $("emptyState").style.display = state.tabs.length ? "none" : "flex";
+  $("filebar").style.display = state.tabs.length ? "flex" : "none";
+}
+
+// ---------- view rendering ---------------------------------------------------
+
+function applyFont() {
+  document.documentElement.style.setProperty("--row-fs", `${state.fontSize}px`);
+  rowH = state.fontSize + 8;
+  document.documentElement.style.setProperty("--row-h", `${rowH}px`);
+  localStorage.setItem("lv.fontSize", String(state.fontSize));
+  document.documentElement.style.setProperty(
+    "--log-font",
+    state.fontFamily === "default"
+      ? '"Cascadia Code", Consolas, "SF Mono", Menlo, "Courier New", monospace'
+      : state.fontFamily,
+  );
+  localStorage.setItem("lv.fontFamily", state.fontFamily);
+  const tab = activeTab();
+  if (tab) {
+    if (hasViewFilter(tab)) renderFilteredViewport(tab);
+    else renderWindow(tab, lineAtScroll());
+  }
+}
+
+function lineAtScroll() {
+  return Math.max(1, Math.floor(scroller.scrollTop / rowH) + 1);
+}
+
+function visibleCount() {
+  return Math.max(1, Math.ceil(scroller.clientHeight / rowH));
+}
+
+function spacerHeight(tab) {
+  const lines = hasViewFilter(tab) ? tab.feedCount : Math.max(tab.totalLines, 1);
+  return Math.max(lines, 1) * rowH;
+}
+
+function updateSpacer(tab) {
+  spacer.style.height = `${spacerHeight(tab)}px`;
+}
+
+function levelClass(line) {
+  const level = LogLevel.detectLevel(line);
+  return level && level !== "other" ? ` lv-${level}` : "";
+}
+
+function buildText(tab, text) {
+  // returns a DocumentFragment with <mark> highlights when a search is active
+  const frag = document.createDocumentFragment();
+  const s = tab && tab.search && tab.search.query ? tab.search : null;
+  if (!s) {
+    frag.append(text);
+    return frag;
+  }
+  let terms;
+  try {
+    terms = LogQuery.parseQuery(s.query, { isRegex: s.isRegex }).includeTerms;
+  } catch {
+    terms = [];
+  }
+  const ranges = [];
+  for (const term of terms) {
+    if (s.isRegex) {
+      try {
+        LogQuery.assertSafeRegex(term);
+        const re = new RegExp(term, s.caseSensitive ? "g" : "gi");
+        let m;
+        while ((m = re.exec(text)) && ranges.length < 200) {
+          if (m[0].length === 0) {
+            re.lastIndex += 1;
+            continue;
+          }
+          ranges.push([m.index, m.index + m[0].length]);
+        }
+      } catch {
+        // The engine reports invalid expressions; a stale row simply has no mark.
+      }
+    } else {
+      const hay = s.caseSensitive ? text : text.toLowerCase();
+      const needle = s.caseSensitive ? term : term.toLowerCase();
+      let idx = hay.indexOf(needle);
+      while (idx !== -1 && ranges.length < 200) {
+        ranges.push([idx, idx + needle.length]);
+        idx = hay.indexOf(needle, idx + Math.max(needle.length, 1));
+      }
+    }
+  }
+  if (!ranges.length) {
+    frag.append(text);
+    return frag;
+  }
+  ranges.sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged = [];
+  for (const range of ranges) {
+    const previous = merged[merged.length - 1];
+    if (previous && range[0] <= previous[1]) previous[1] = Math.max(previous[1], range[1]);
+    else merged.push(range);
+  }
+  let pos = 0;
+  for (const [a, b] of merged) {
+    if (a > pos) frag.append(text.slice(pos, a));
+    const mark = document.createElement("mark");
+    mark.textContent = text.slice(a, b);
+    frag.append(mark);
+    pos = b;
+  }
+  if (pos < text.length) frag.append(text.slice(pos));
+  return frag;
+}
+
+function paintRows(tab, rows, { absolute, offset = 0 }) {
+  spacer.textContent = "";
+  const currentLine = tab.search && tab.search.current >= 0 && tab.search.currentLine ? tab.search.currentLine : null;
+  const frag = document.createDocumentFragment();
+  for (let i = 0; i < rows.length; i += 1) {
+    const item = rows[i];
+    const row = document.createElement("div");
+    row.className = `row${levelClass(item.text)}${currentLine === item.no ? " current" : ""}`;
+    const top = absolute ? (item.no - 1) * rowH : (offset + i) * rowH;
+    row.style.top = `${top}px`;
+    const lno = document.createElement("div");
+    lno.className = "lno";
+    lno.textContent = item.no;
+    lno.title = "点击复制整行";
+    lno.addEventListener("click", () => copyLine(item.text, item.no));
+    const ltxt = document.createElement("div");
+    ltxt.className = "ltxt";
+    ltxt.append(buildText(tab, item.text));
+    ltxt.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      openCtxMenu(e, item.text, item.no);
+    });
+    row.append(lno, ltxt);
+    frag.append(row);
+  }
+  spacer.append(frag);
+}
+
+function renderWindow(tab, fromLine) {
+  if (hasViewFilter(tab)) {
+    loadMoreFiltered(tab);
+    renderFilteredViewport(tab);
+    return;
+  }
+  fromLine = Math.max(1, Math.floor(fromLine) || 1);
+  const token = (tab.renderToken = (tab.renderToken || 0) + 1);
+  const count = visibleCount() + OVERSCAN * 2;
+  const from = Math.max(1, fromLine - OVERSCAN);
+  tab.adapter
+    .page({ fileId: tab.fileId, fromLine: from, count, levels: null, filter: null })
+    .then((res) => {
+      if (token !== tab.renderToken || state.activeId !== tab.id) return;
+      tab.totalLines = res.totalLines;
+      tab.indexDone = res.indexDone;
+      tab.size = res.size;
+      tab.stats = res.stats;
+      tab.seenSize = res.size;
+      tab.window = { from, lines: res.lines, eof: res.eof, hasMore: res.hasMore };
+      updateBadges(tab);
+      updateStatus(tab);
+      if (hasViewFilter(tab)) {
+        // Filter state flipped while the page was in flight — drop the unfiltered window.
+        renderFilteredViewport(tab);
+      } else {
+        updateSpacer(tab);
+        paintRows(tab, res.lines, { absolute: true });
+        if (res.eof && !res.lines.length && fromLine > 1) {
+          // scrolled past EOF (index lag) — pull back to the indexed tail
+          scroller.scrollTop = Math.max(0, res.totalLines * rowH - scroller.clientHeight);
+        }
+      }
+      scheduleSaveState();
+    })
+    .catch((err) => toast(`读取失败: ${err.message || err}`));
+}
+
+function dedupeAppend(existing, fresh) {
+  if (!existing.length) return fresh.slice();
+  const lastNo = existing[existing.length - 1].no;
+  return existing.concat(fresh.filter((x) => x.no > lastNo));
+}
+
+/** Virtual-scroll paint: only the visible slice of the filtered feed. */
+function renderFilteredViewport(tab) {
+  const rows = tab.feedRows || [];
+  updateSpacer(tab);
+  if (!rows.length) {
+    spacer.textContent = "";
+    tab._fpaintKey = "empty";
+    return;
+  }
+  const start = Math.max(0, Math.floor(scroller.scrollTop / rowH) - OVERSCAN);
+  const end = Math.min(rows.length, start + visibleCount() + OVERSCAN * 2);
+  const key = `${start}:${end}:${rows.length}:${tab.search ? tab.search.query : ""}:${tab.search && tab.search.currentLine}`;
+  if (tab._fpaintKey === key) return;
+  tab._fpaintKey = key;
+  paintRows(tab, rows.slice(start, end), { absolute: false, offset: start });
+}
+
+function renderFilteredReset(tab) {
+  tab.feedRows = [];
+  tab.feedCount = 0;
+  tab.feedFrom = 1;
+  tab.paintedFeed = 0;
+  tab.filterEof = false;
+  tab._fpaintKey = null;
+  scroller.scrollTop = 0;
+  updateSpacer(tab);
+  loadMoreFiltered(tab);
+}
+
+/** Load the next batch of matching rows (also continues past empty windows). */
+async function loadMoreFiltered(tab) {
+  if (!hasViewFilter(tab) || tab.loadingMore || tab.filterEof) return;
+  tab.loadingMore = true;
+  try {
+    for (let guard = 0; guard < 30; guard += 1) {
+      const res = await tab.adapter.page({
+        fileId: tab.fileId,
+        fromLine: tab.feedFrom,
+        count: Math.max(visibleCount() * 2, 80),
+        ...pageFilters(tab),
+      });
+      tab.totalLines = res.totalLines;
+      tab.indexDone = res.indexDone;
+      tab.size = res.size;
+      tab.seenSize = res.size;
+      tab.stats = res.stats;
+      const existing = tab.feedRows || [];
+      const merged = dedupeAppend(existing, res.lines);
+      const newRows = merged.slice(existing.length);
+      tab.feedRows = merged;
+      tab.feedCount = merged.length;
+      tab.feedFrom = merged.length ? merged[merged.length - 1].no + 1 : res.scanEndLine || tab.feedFrom;
+      tab.filterEof = Boolean(res.eof);
+      tab._fpaintKey = null;
+      updateSpacer(tab);
+      renderFilteredViewport(tab);
+      updateBadges(tab);
+      updateStatus(tab);
+      if (res.eof) break;
+      if (newRows.length > 0) break; // painted content; wait for the next scroll
+      if (!res.scanEndLine || res.scanEndLine <= tab.feedFrom) break; // no progress
+      tab.feedFrom = res.scanEndLine; // empty window: keep scanning
+    }
+  } catch (err) {
+    toast(`过滤视图加载失败: ${err.message || err}`);
+  } finally {
+    tab.loadingMore = false;
+  }
+}
+
+// follow-mode helpers ---------------------------------------------------------
+
+function scrollToTail(tab, { enableFollow = false } = {}) {
+  if (hasViewFilter(tab)) return;
+  const target = Math.max(1, tab.totalLines - visibleCount() + 1);
+  tab.viewLine = target;
+  scroller.scrollTop = (target - 1) * rowH;
+  renderWindow(tab, target);
+  if (enableFollow && !tab.follow) setFollow(tab, true);
+}
+
+async function setFollow(tab, on) {
+  tab.follow = Boolean(on);
+  try {
+    await tab.adapter.setFollow({ fileId: tab.fileId, follow: tab.follow });
+  } catch {
+    // The host owns the follow handle; a closed file is reported on poll.
+  }
+  updateFollowState(tab);
+  if (tab.follow) scrollToTail(tab);
+  scheduleSaveState();
+}
+
+function updateFollowState(tab) {
+  const el = $("stFollow");
+  el.classList.remove("on", "paused");
+  if (!tab) {
+    el.textContent = "";
+    return;
+  }
+  if (tab.follow) {
+    el.classList.add("on");
+    el.textContent = "实时跟随中";
+    $("btnFollow").classList.add("toggled");
+  } else {
+    el.textContent = tab.mode === "native" ? "跟随已暂停" : "";
+    $("btnFollow").classList.remove("toggled");
+  }
+}
+
+// ---------- poll loop --------------------------------------------------------
+
+async function tick() {
+  for (const tab of state.tabs) {
+    if (tab.mode === "native" && tab.fileId) {
+      try {
+        const res = await tab.adapter.poll({ fileId: tab.fileId, sinceLine: tab.lastLine });
+        applyPoll(tab, res);
+      } catch (err) {
+        if (String(err && err.message).includes("not open")) {
+          tab.error = "文件句柄已失效";
+        }
+      }
+    }
+  }
+  const active = activeTab();
+  if (active && active.search && active.search.status === "running") {
+    try {
+      await pollSearch(active);
+    } catch {
+      // job pruned
+    }
+  }
+}
+
+function applyPoll(tab, res) {
+  if (res.missing) {
+    if (tab.error !== "missing") {
+      tab.error = "missing";
+      if (tab.id === state.activeId) {
+        toast(`文件已不存在: ${tab.name}`);
+        $("stLines").textContent = "文件已丢失";
+      }
+    }
+    return;
+  }
+  tab.error = null;
+  const prevSize = tab.seenSize != null ? tab.seenSize : tab.size;
+  const sizeGrew = res.size > prevSize;
+  tab.seenSize = res.size;
+  tab.size = res.size;
+  tab.totalLines = res.totalLines;
+  tab.indexDone = res.indexDone;
+  tab.stats = res.stats;
+  const rotated = res.rotated || (res.events || []).some((e) => e.type === "rotated");
+  if (tab.id !== state.activeId) {
+    // Keep bookkeeping only; UI belongs to the active tab.
+    for (const ev of res.events || []) {
+      if (ev.type === "append" || ev.type === "catchup") {
+        tab.lastLine = ev.totalLines;
+        tab.totalLines = ev.totalLines;
+      } else if (ev.type === "rotated") {
+        tab.lastLine = 0;
+        tab.search = null;
+      }
+    }
+    return;
+  }
+  if (rotated) {
+    toast(`日志已轮转，重新加载: ${tab.name}`);
+    tab.lastLine = 0;
+    tab.search = null;
+    updateSearchBar(tab);
+    if (tab.follow) {
+      renderWindow(tab, 1);
+      setTimeout(() => scrollToTail(tab), 600);
+    } else {
+      renderWindow(tab, 1);
+    }
+    updateBadges(tab);
+    updateStatus(tab);
+    return;
+  }
+  for (const ev of res.events || []) {
+    if (ev.type === "append") {
+      const newCount = ev.totalLines - (tab.tailSeen || tab.lastLine);
+      tab.lastLine = ev.totalLines;
+      tab.totalLines = ev.totalLines;
+      if (tab.follow && atBottom()) {
+        if (hasViewFilter(tab)) loadMoreFiltered(tab);
+        else {
+          updateSpacer(tab);
+          renderWindow(tab, Math.max(1, tab.totalLines - visibleCount() + 1));
+        }
+        scroller.scrollTop = scroller.scrollHeight;
+      } else if (!tab.follow && sizeGrew) {
+        // Only real file growth counts as "new"; index catch-up on a static file is silent.
+        showJumpChip(newCount);
+      } else {
+        updateSpacer(tab);
+      }
+    } else if (ev.type === "catchup") {
+      tab.lastLine = ev.totalLines;
+      if (tab.follow) renderWindow(tab, Math.max(1, tab.totalLines - visibleCount() + 1));
+      else if (sizeGrew) showJumpChip(1);
+    }
+  }
+  updateBadges(tab);
+  updateStatus(tab);
+}
+
+function applyStats(tab, res) {
+  tab.stats = res.stats;
+  tab.totalLines = res.totalLines;
+  tab.indexDone = res.indexDone;
+  if (!hasViewFilter(tab)) updateSpacer(tab);
+  updateBadges(tab);
+  updateStatus(tab);
+}
+
+function showJumpChip(newCount) {
+  const chip = $("jumpChip");
+  chip.style.display = "flex";
+  chip.textContent = `↓ ${newCount > 0 ? `${newCount} 行新日志，` : ""}点击回到底部`;
+}
+
+function hideJumpChip() {
+  $("jumpChip").style.display = "none";
+}
+
+// ---------- badges & status --------------------------------------------------
+
+function updateBadges(tab) {
+  const map = { error: 0, warn: 0, info: 0, debug: 0 };
+  Object.assign(map, tab.stats || {});
+  for (const el of $("badges").children) {
+    const lv = el.dataset.level;
+    el.querySelector("b").textContent = String(map[lv] || 0);
+    const stateName = badgeState(tab, lv);
+    el.dataset.state = stateName;
+    el.classList.toggle("on", stateName === "include");
+    el.classList.toggle("exclude", stateName === "exclude");
+    el.title = stateName === "include" ? "仅显示此等级（再次点击改为排除）" : stateName === "exclude" ? "排除该等级（再次点击取消）" : "点击仅显示此等级";
+  }
+  const idx = $("idxProgress");
+  if (!tab || !tab.fileId) {
+    idx.textContent = "";
+    return;
+  }
+  if (tab.indexDone) idx.textContent = "";
+  else idx.textContent = `索引中 L${tab.totalLines}…`;
+}
+
+function updateStatus(tab) {
+  if (!tab) {
+    $("stPos").textContent = "—";
+    $("stLines").textContent = "";
+    $("stSize").textContent = "";
+    $("fName").textContent = "";
+    $("fMeta").textContent = "";
+    return;
+  }
+  $("fName").textContent = tab.name || "";
+  $("fName").title = tab.path || tab.name || "";
+  $("fMeta").textContent = tab.mode === "demo" ? "示例" : tab.mode === "native" ? "本地文件" : "";
+  if (hasViewFilter(tab)) {
+    const kind = hasTextFilter(tab) ? "过滤" : "等级过滤";
+    $("stPos").textContent = `${kind}视图 ${tab.feedCount} 行`;
+    $("stLines").textContent = `源文件已索引 L${tab.totalLines}${tab.indexDone ? "" : "+"}`;
+  } else {
+    const pos = lineAtScroll() + visibleCount() - 1;
+    $("stPos").textContent = `L ${lineAtScroll()}–${Math.min(pos, Math.max(tab.totalLines, 1))}`;
+    $("stLines").textContent = `共 ${tab.totalLines} 行${tab.indexDone ? "" : "（索引中…）"}`;
+  }
+  $("stSize").textContent = fmtSize(tab.size);
+  $("encodingSel").value = tab.encoding;
+  updateFollowState(tab);
+}
+
+// ---------- text filter ------------------------------------------------------
+
+function startFilter() {
+  const tab = activeTab();
+  if (!tab) return;
+  const query = $("filterInput").value.trim();
+  if (!query) {
+    clearTextFilter(tab);
+    return;
+  }
+  rememberPreFilterScroll(tab);
+  tab.filter = {
+    query,
+    isRegex: $("cbFilterRegex").checked,
+    caseSensitive: $("cbFilterCase").checked,
+    invert: $("cbFilterInvert").checked,
+  };
+  updateFilterBar(tab);
+  renderFilteredReset(tab);
+  updateStatus(tab);
+  scheduleSaveState();
+}
+
+function clearTextFilter(tab) {
+  if (!tab) return;
+  tab.filter = null;
+  $("filterInput").value = "";
+  updateFilterBar(tab);
+  if (hasViewFilter(tab)) {
+    renderFilteredReset(tab);
+  } else {
+    exitToUnfilteredView(tab);
+  }
+  updateStatus(tab);
+  scheduleSaveState();
+}
+
+/** 清空过滤 + 等级筛选，恢复未过滤视图。 */
+function clearAllFilters(tab) {
+  if (!tab) return;
+  tab.filter = null;
+  $("filterInput").value = "";
+  tab.levels = null;
+  tab.excludedLevels = null;
+  updateFilterBar(tab);
+  updateBadges(tab);
+  exitToUnfilteredView(tab);
+  scheduleSaveState();
+}
+
+function updateFilterBar(tab) {
+  const f = tab && tab.filter;
+  const el = $("filterState");
+  if (!f || !String(f.query || "").trim()) {
+    el.textContent = "";
+    $("btnFilterClear").disabled = !(tab && hasLevelFilter(tab));
+    return;
+  }
+  const mode = f.invert ? "隐藏匹配" : "仅显示匹配";
+  el.innerHTML = "";
+  const b = document.createElement("b");
+  b.textContent = mode;
+  el.append(b, document.createTextNode(` ${f.query}`));
+  $("btnFilterClear").disabled = false;
+}
+
+function syncFilterInputs(tab) {
+  const f = tab && tab.filter;
+  $("filterInput").value = f ? f.query : "";
+  $("cbFilterRegex").checked = Boolean(f && f.isRegex);
+  $("cbFilterCase").checked = Boolean(f && f.caseSensitive);
+  $("cbFilterInvert").checked = Boolean(f && f.invert);
+  updateFilterBar(tab);
+}
+
+// ---------- search -----------------------------------------------------------
+
+function startSearch() {
+  const tab = activeTab();
+  if (!tab) return;
+  const query = $("searchInput").value.trim();
+  if (!query) return;
+  const isRegex = $("cbRegex").checked;
+  const payload = {
+    fileId: tab.fileId,
+    query,
+    isRegex,
+    caseSensitive: $("cbCase").checked,
+  };
+  tab.adapter
+    .searchStart(payload)
+    .then((res) => {
+      tab.search = {
+        jobId: res.jobId,
+        query,
+        isRegex: payload.isRegex,
+        caseSensitive: payload.caseSensitive,
+        status: "running",
+        matchCount: 0,
+        stored: 0,
+        current: -1,
+        currentLine: null,
+        cache: null,
+      };
+      updateSearchBar(tab);
+      repaintCurrentWindow(tab);
+    })
+    .catch((err) => toast(`搜索失败: ${err.message || err}`));
+}
+
+async function pollSearch(tab) {
+  if (!tab.search || !tab.search.jobId) return;
+  try {
+    const st = await tab.adapter.searchStatus({ fileId: tab.fileId, jobId: tab.search.jobId });
+    tab.search.status = st.status;
+    tab.search.matchCount = st.matchCount;
+    tab.search.stored = st.storedMatches;
+    if (st.error) tab.search.error = st.error;
+    updateSearchBar(tab);
+    if (st.status !== "running") await jumpMatch(tab, tab.search.current < 0 ? 0 : tab.search.current);
+  } catch {
+    // job pruned or file closed
+  }
+}
+
+function updateSearchBar(tab) {
+  const s = tab && tab.search;
+  const el = $("searchState");
+  const prev = $("btnPrevMatch");
+  const next = $("btnNextMatch");
+  if (!s) {
+    el.textContent = "";
+    prev.disabled = true;
+    next.disabled = true;
+    return;
+  }
+  const navigable = Math.min(s.matchCount, s.stored || 0);
+  prev.disabled = navigable === 0;
+  next.disabled = navigable === 0;
+  if (s.status === "running") {
+    el.textContent = `扫描中 · 已命中 ${s.matchCount}`;
+  } else if (s.status === "cancelled") {
+    el.textContent = "已取消";
+  } else if (s.status === "error") {
+    el.textContent = s.error || "搜索失败";
+  } else {
+    const cur = s.current >= 0 ? ` · ${s.current + 1}/${navigable}` : "";
+    const capNote = s.stored < s.matchCount ? `（仅定位前 ${s.stored} 处）` : "";
+    el.innerHTML = "";
+    const b = document.createElement("b");
+    b.textContent = `命中 ${s.matchCount}`;
+    el.append(b, document.createTextNode(`${cur}${capNote}`));
+  }
+}
+
+function repaintCurrentWindow(tab) {
+  if (hasViewFilter(tab)) {
+    tab._fpaintKey = null;
+    renderFilteredViewport(tab);
+    return;
+  }
+  if (!tab.window) return;
+  paintRows(tab, tab.window.lines, { absolute: true });
+}
+
+async function jumpMatch(tab, index) {
+  const s = tab.search;
+  if (!s || !s.jobId) return;
+  if (s.matchCount === 0) {
+    updateSearchBar(tab);
+    return;
+  }
+  const stored = s.stored || 0;
+  if (stored === 0) return;
+  index = ((Math.floor(index) % stored) + stored) % stored;
+  const windowStart = Math.max(0, index - 60);
+  const res = await tab.adapter.searchMatches({ fileId: tab.fileId, jobId: s.jobId, offset: windowStart, limit: 160 });
+  s.cache = { offset: windowStart, items: res.matches };
+  const item = res.matches[index - windowStart];
+  s.current = index;
+  s.currentLine = item ? item.line : null;
+  updateSearchBar(tab);
+  if (item) {
+    if (hasViewFilter(tab)) {
+      let visibleIndex = (tab.feedRows || []).findIndex((row) => row.no === item.line);
+      for (let guard = 0; visibleIndex < 0 && guard < 100 && !tab.filterEof; guard += 1) {
+        const before = tab.feedRows ? tab.feedRows.length : 0;
+        await loadMoreFiltered(tab);
+        if ((tab.feedRows ? tab.feedRows.length : 0) === before) break;
+        visibleIndex = (tab.feedRows || []).findIndex((row) => row.no === item.line);
+      }
+      if (visibleIndex >= 0) {
+        scroller.scrollTop = Math.max(0, visibleIndex * rowH - scroller.clientHeight / 2);
+        tab._fpaintKey = null;
+        renderFilteredViewport(tab);
+      } else {
+        toast(`命中位于 L${item.line}，不在当前过滤视图`);
+      }
+    } else {
+      scroller.scrollTop = Math.max(0, (item.line - 1) * rowH - scroller.clientHeight / 2);
+      renderWindow(tab, item.line - Math.floor(visibleCount() / 2));
+    }
+  }
+}
+
+function clearSearch(tab) {
+  if (!tab || !tab.search) return;
+  tab.adapter.searchCancel({ fileId: tab.fileId, jobId: tab.search.jobId }).catch(() => {});
+  tab.search = null;
+  updateSearchBar(tab);
+  repaintCurrentWindow(tab);
+}
+
+async function jumpToLine(tab, target) {
+  if (!tab || !Number.isInteger(target) || target < 1) return;
+  if (!hasViewFilter(tab)) {
+    if (tab.indexDone && target > tab.totalLines) {
+      toast(`行号超出范围（共 ${tab.totalLines} 行）`);
+      return;
+    }
+    tab.viewLine = target;
+    tab.lastLine = target;
+    scroller.scrollTop = (target - 1) * rowH;
+    renderWindow(tab, Math.max(1, target - Math.floor(visibleCount() / 2)));
+    return;
+  }
+  for (let guard = 0; guard < 100 && !tab.filterEof; guard += 1) {
+    const found = (tab.feedRows || []).findIndex((item) => item.no >= target);
+    if (found >= 0) {
+      scroller.scrollTop = Math.max(0, found * rowH - scroller.clientHeight / 2);
+      tab._fpaintKey = null;
+      renderFilteredViewport(tab);
+      updateStatus(tab);
+      return;
+    }
+    const before = tab.feedRows ? tab.feedRows.length : 0;
+    await loadMoreFiltered(tab);
+    if ((tab.feedRows ? tab.feedRows.length : 0) === before) break;
+  }
+  const found = (tab.feedRows || []).findIndex((item) => item.no >= target);
+  if (found >= 0) {
+    scroller.scrollTop = Math.max(0, found * rowH - scroller.clientHeight / 2);
+    tab._fpaintKey = null;
+    renderFilteredViewport(tab);
+  } else {
+    toast(`过滤视图中没有不小于 L${target} 的行`);
+  }
+}
+
+function promptJumpToLine() {
+  const tab = activeTab();
+  if (!tab) return;
+  const raw = window.prompt("跳转到行号", String(lineAtScroll()));
+  if (raw === null) return;
+  const target = Number(raw.trim());
+  if (!Number.isSafeInteger(target) || target < 1) {
+    toast("请输入正整数行号");
+    return;
+  }
+  jumpToLine(tab, target).catch((err) => toast(`跳转失败: ${err.message || err}`));
+}
+
+// ---------- tabs activation & view ------------------------------------------
+
+function activateView() {
+  const tab = activeTab();
+  hideJumpChip();
+  $("searchInput").value = tab && tab.search ? tab.search.query : "";
+  updateSearchBar(tab);
+  syncFilterInputs(tab);
+  if (!tab) {
+    spacer.textContent = "";
+    spacer.style.height = "0px";
+    renderPins(null);
+    updateStatus(null);
+    updateBadges({ stats: {}, levels: null });
+    updateFollowState(null);
+    return;
+  }
+  if (hasViewFilter(tab)) {
+    if (!tab.feedRows) renderFilteredReset(tab);
+    else {
+      tab._fpaintKey = null;
+      updateSpacer(tab);
+      renderFilteredViewport(tab);
+    }
+  } else {
+    // 先对齐滚动位置，再按视口首行取窗口，避免顶部空白、内容错位
+    const view = Math.max(1, tab.viewLine || 1);
+    tab.viewLine = view;
+    scroller.scrollTop = Math.max(0, (view - 1) * rowH);
+    renderWindow(tab, view);
+    if (tab.follow) setTimeout(() => scrollToTail(tab), 0);
+  }
+  renderPins(tab);
+  updateStatus(tab);
+  updateBadges(tab);
+}
+
+// ---------- open files -------------------------------------------------------
+
+let dirCtx = { path: null, selected: new Map() };
+
+/** 仅接受常见日志扩展名。 */
+function isLogFileName(name) {
+  const n = String(name || "").toLowerCase();
+  return n.endsWith(".log") || n.endsWith(".txt");
+}
+
+function filterLogEntries(entries) {
+  return (entries || []).filter((ent) => !ent.isDirectory && isLogFileName(ent.name || ent.path));
+}
+
+/**
+ * 打开日志：系统文件选择器（仅 .log / .txt），多选。
+ * 路径解析复用拖入文件的 grant 通道；不支持时回退为「选目录 → 只列日志」。
+ */
+async function openFilesFlow() {
+  if (typeof bridge.getDroppedFilePath === "function") {
+    openViaNativeFilePicker();
+    return;
+  }
+  await openViaDirectoryFallback();
+}
+
+function openViaNativeFilePicker() {
+  const input = $("filePicker");
+  input.accept = ".log,.txt,.LOG,.TXT,text/plain";
+  input.multiple = true;
+  input.value = "";
+  input.onchange = async () => {
+    const files = [...(input.files || [])];
+    input.value = "";
+    if (!files.length) return;
+    let opened = 0;
+    for (const f of files) {
+      if (!isLogFileName(f.name)) {
+        toast(`已跳过：${f.name}（仅支持 .log / .txt）`);
+        continue;
+      }
+      const tab = await openPickedOrDroppedFile(f, { source: "picker" });
+      if (tab) opened += 1;
+    }
+    if (!opened) return;
+  };
+  input.click();
+}
+
+/** 宿主无拖入/选文件路径解析时的回退：选目录后只列出 .log / .txt。 */
+async function openViaDirectoryFallback() {
+  let dir;
+  try {
+    dir = await bridge.invoke("fs.requestDirectory");
+  } catch (err) {
+    toast(`选择目录失败: ${err.message || err}`);
+    return;
+  }
+  if (!dir) return;
+  try {
+    await invoke("engine.setRoot", { path: "" });
+  } catch (err) {
+    toast(`绑定目录失败: ${err.message || err}`);
+    return;
+  }
+  dirCtx = { path: "", selected: new Map() };
+  await loadFileList("");
+  $("dirOverlay").classList.add("show");
+}
+
+async function loadFileList(path) {
+  const res = await invoke("engine.listDir", { path });
+  dirCtx.path = res.path;
+  dirCtx.selected.clear();
+  const list = $("fileList");
+  list.textContent = "";
+  $("dirPath").textContent = res.path || "当前选择的目录（仅显示 .log / .txt）";
+  const entries = filterLogEntries(res.entries);
+  if (!entries.length) {
+    const empty = document.createElement("div");
+    empty.className = "f-row";
+    empty.style.color = "rgb(var(--c-faint))";
+    empty.textContent = "该目录下没有 .log / .txt 日志文件";
+    list.append(empty);
+  }
+  for (const ent of entries) {
+    const row = document.createElement("div");
+    row.className = "f-row";
+    const cb = document.createElement("input");
+    cb.type = "checkbox";
+    const name = document.createElement("span");
+    name.textContent = ent.name;
+    name.style.overflow = "hidden";
+    name.style.textOverflow = "ellipsis";
+    const size = document.createElement("span");
+    size.className = "f-size";
+    size.textContent = fmtSize(ent.size);
+    const time = document.createElement("span");
+    time.className = "f-time";
+    time.textContent = fmtTime(ent.mtimeMs);
+    cb.addEventListener("change", () => {
+      if (cb.checked) dirCtx.selected.set(ent.path, ent);
+      else dirCtx.selected.delete(ent.path);
+      $("dirSelInfo").textContent = dirCtx.selected.size ? `已选择 ${dirCtx.selected.size} 个文件` : "未选择";
+      $("dirOpen").disabled = dirCtx.selected.size === 0;
+    });
+    row.append(cb, name, size, time);
+    row.addEventListener("click", (e) => {
+      if (e.target !== cb) {
+        cb.checked = !cb.checked;
+        cb.dispatchEvent(new Event("change"));
+      }
+    });
+    list.append(row);
+  }
+  $("dirSelInfo").textContent = "未选择";
+  $("dirOpen").disabled = true;
+}
+
+async function openSelectedFiles() {
+  const paths = [...dirCtx.selected.keys()];
+  $("dirOverlay").classList.remove("show");
+  for (const p of paths) {
+    await openNativeFile(p);
+  }
+}
+
+function openDemoLog() {
+  const existing = state.tabs.find((t) => t.mode === "demo");
+  if (existing) {
+    activateTab(existing.id);
+    return existing;
+  }
+  const lines = DEMO_LOG_LINES;
+  const size = lines.reduce((n, l) => n + l.length + 1, 0);
+  const tab = createTab({ mode: "demo", name: "使用引导（示例日志）", path: null, adapter: createDemoAdapter() });
+  tab.fileId = 0;
+  tab.demo = true;
+  tab.size = size;
+  tab.seenSize = size;
+  tab.totalLines = lines.length;
+  tab.indexDone = true;
+  tab.stats = computeDemoStats(lines);
+  tab.lastLine = lines.length; // 轮询游标：无新增
+  tab.viewLine = 1; // 打开即从第一行看起
+  activateTab(tab.id);
+  return tab;
+}
+
+async function openNativeFile(path) {
+  try {
+    const res = await invoke("engine.openFile", { path });
+    const existing = state.tabs.find((t) => t.mode === "native" && t.path === path);
+    if (existing) {
+      existing.fileId = res.fileId;
+      activateTab(existing.id);
+      return existing;
+    }
+    const tab = createTab({ mode: "native", name: res.name, path, adapter: createNativeAdapter() });
+    tab.fileId = res.fileId;
+    tab.size = res.size;
+    tab.seenSize = res.size;
+    tab.totalLines = res.totalLines;
+    tab.indexDone = res.indexDone;
+    tab.encoding = res.encoding;
+    tab.stats = res.stats;
+    // Static open: poll cursor at EOF so index catch-up is not "new"; view starts at top.
+    tab.lastLine = Math.max(0, res.totalLines || 0);
+    tab.viewLine = 1;
+    activateTab(tab.id);
+    return tab;
+  } catch (err) {
+    toast(`打开失败: ${err.message || err}`);
+    return null;
+  }
+}
+
+/** 选择器 / 拖入共用：解析本地路径 → 注册 grant → 打开。 */
+async function openPickedOrDroppedFile(file, { source = "drop" } = {}) {
+  const key = `${file.name}:${file.size}`;
+  const existing = state.tabs.find((t) => t.dropKey === key);
+  if (existing) {
+    activateTab(existing.id);
+    return existing;
+  }
+  if (!isLogFileName(file.name)) {
+    toast(`已跳过：${file.name}（仅支持 .log / .txt）`);
+    return null;
+  }
+  if (typeof bridge.getDroppedFilePath !== "function") {
+    toast("当前宿主不支持解析文件路径，请使用「打开日志」选择目录");
+    return null;
+  }
+  const path = bridge.getDroppedFilePath(file);
+  if (!path) {
+    toast(source === "picker" ? "无法解析所选文件路径" : "无法解析拖入文件路径");
+    return null;
+  }
+  let grant;
+  try {
+    grant = await bridge.invoke("fs.registerDropped", { path });
+  } catch (err) {
+    toast(`${source === "picker" ? "打开" : "拖入"}文件授权失败: ${err.message || err}`);
+    return null;
+  }
+  const adapter = createNativeAdapter();
+  const tab = createTab({ mode: "native", name: file.name, adapter, saved: null });
+  tab.dropKey = key;
+  try {
+    const res = await invoke("engine.openDropped", { path, grantId: grant.grantId });
+    tab.fileId = res.fileId;
+    tab.path = path; // 记录绝对路径，便于会话内展示
+    tab.size = res.size;
+    tab.seenSize = res.size;
+    tab.totalLines = res.totalLines;
+    tab.indexDone = res.indexDone;
+    tab.encoding = res.encoding;
+    tab.stats = res.stats;
+    tab.lastLine = Math.max(0, res.totalLines || 0);
+    tab.viewLine = 1;
+    activateTab(tab.id);
+    toast(source === "picker" ? `已打开: ${file.name}` : `已打开拖入文件: ${file.name}`);
+    return tab;
+  } catch (err) {
+    toast(`打开失败: ${err.message || err}`);
+    closeTab(tab.id);
+    return null;
+  }
+}
+
+async function openDroppedFile(file) {
+  return openPickedOrDroppedFile(file, { source: "drop" });
+}
+
+// ---------- clipboard & context menu ----------------------------------------
+
+async function copyLine(text, no) {
+  try {
+    await bridge.invoke("clipboard.writeText", { text });
+    toast(`已复制 L${no}`);
+  } catch (err) {
+    toast(`复制失败: ${err.message || err}`);
+  }
+}
+
+function openCtxMenu(e, lineText, lineNo) {
+  const tab = activeTab();
+  const menu = $("ctxMenu");
+  const no = Number(lineNo) || null;
+  const pinned = no != null && tab && (tab.pins || []).some((p) => p.no === no);
+  menu.style.left = `${Math.min(e.clientX, window.innerWidth - 220)}px`;
+  menu.style.top = `${Math.min(e.clientY, window.innerHeight - 140)}px`;
+  menu.classList.add("show");
+  $("ctxCopyLine").onclick = () => {
+    menu.classList.remove("show");
+    copyLine(lineText, no != null ? no : "");
+  };
+  $("ctxCopySel").onclick = () => {
+    menu.classList.remove("show");
+    const sel = String(document.getSelection());
+    if (sel) bridge.invoke("clipboard.writeText", { text: sel }).then(() => toast("已复制选中内容"));
+  };
+  const pinBtn = $("ctxPinLine");
+  pinBtn.textContent = pinned ? "取消钉住" : "钉住此行";
+  pinBtn.style.display = no != null && tab ? "" : "none";
+  pinBtn.onclick = () => {
+    menu.classList.remove("show");
+    if (!tab || no == null) return;
+    if (pinned) unpinLine(tab, no);
+    else pinLine(tab, no, lineText);
+  };
+  const jumpBtn = $("ctxClearJump");
+  jumpBtn.style.display = tab && hasViewFilter(tab) && no != null ? "" : "none";
+  jumpBtn.onclick = () => {
+    menu.classList.remove("show");
+    if (!tab || no == null) return;
+    tab.preFilterLine = no;
+    clearAllFilters(tab);
+    toast(`已清除筛选并定位 L${no}`);
+  };
+}
+
+// ---------- 钉住行 -----------------------------------------------------------
+
+function pinLine(tab, no, text) {
+  if (!tab || !no) return;
+  if (!Array.isArray(tab.pins)) tab.pins = [];
+  if (tab.pins.some((p) => p.no === no)) return;
+  if (tab.pins.length >= MAX_PINS) {
+    toast(`最多钉住 ${MAX_PINS} 行，请先取消一条`);
+    return;
+  }
+  tab.pins.push({ no, text: String(text || "") });
+  tab.pins.sort((a, b) => a.no - b.no);
+  renderPins(tab);
+  toast(`已钉住 L${no}`);
+}
+
+function unpinLine(tab, no) {
+  if (!tab || !Array.isArray(tab.pins)) return;
+  tab.pins = tab.pins.filter((p) => p.no !== no);
+  renderPins(tab);
+}
+
+function renderPins(tab) {
+  const bar = $("pinBar");
+  if (!bar) return;
+  const pins = tab && Array.isArray(tab.pins) ? tab.pins : [];
+  if (!pins.length) {
+    bar.textContent = "";
+    bar.classList.add("hidden");
+    return;
+  }
+  bar.classList.remove("hidden");
+  bar.textContent = "";
+  for (const pin of pins) {
+    const row = document.createElement("div");
+    row.className = "pin-row";
+    row.title = "点击跳转到该行";
+    const lno = document.createElement("span");
+    lno.className = "pin-lno";
+    lno.textContent = `L${pin.no}`;
+    const tag = document.createElement("span");
+    tag.className = "pin-tag";
+    tag.textContent = "钉";
+    const txt = document.createElement("span");
+    txt.className = "pin-txt";
+    txt.textContent = pin.text;
+    const x = document.createElement("button");
+    x.className = "pin-x";
+    x.type = "button";
+    x.title = "取消钉住";
+    x.textContent = "✕";
+    x.addEventListener("click", (e) => {
+      e.stopPropagation();
+      unpinLine(tab, pin.no);
+    });
+    row.addEventListener("click", () => {
+      hideJumpChip();
+      jumpToLine(tab, pin.no).catch(() => {});
+    });
+    row.append(lno, tag, txt, x);
+    bar.append(row);
+  }
+}
+
+// ---------- theme ------------------------------------------------------------
+
+function applyTheme(theme) {
+  const next = theme === "light" ? "light" : "dark";
+  document.documentElement.dataset.theme = next;
+  applyLevelColors(next);
+  const btn = $("btnTheme");
+  if (btn) {
+    const isDark = next === "dark";
+    btn.innerHTML = isDark ? SVG_SUN : SVG_MOON;
+    btn.title = isDark ? "切换到米白主题" : "切换到黑夜主题";
+  }
+}
+
+function setSearchBarVisible(on, { focus = false } = {}) {
+  const bar = $("searchbar");
+  const toggle = $("btnToggleSearch");
+  if (!bar) return;
+  bar.classList.toggle("hidden", !on);
+  if (toggle) toggle.classList.toggle("toggled", on);
+  if (on && focus) {
+    const input = $("searchInput");
+    if (input) {
+      input.focus();
+      input.select();
+    }
+  }
+}
+
+function setFilterBarVisible(on, { focus = false } = {}) {
+  const bar = $("filterbar");
+  const toggle = $("btnToggleFilter");
+  if (!bar) return;
+  bar.classList.toggle("hidden", !on);
+  if (toggle) toggle.classList.toggle("toggled", on);
+  if (on && focus) {
+    const input = $("filterInput");
+    if (input) {
+      input.focus();
+      input.select();
+    }
+  }
+}
+
+function isSearchBarVisible() {
+  const bar = $("searchbar");
+  return Boolean(bar && !bar.classList.contains("hidden"));
+}
+
+function isFilterBarVisible() {
+  const bar = $("filterbar");
+  return Boolean(bar && !bar.classList.contains("hidden"));
+}
+
+function currentHostTheme() {
+  return document.documentElement.classList.contains("light") ||
+    (window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches)
+    ? "light"
+    : "dark";
+}
+
+// ---------- events -----------------------------------------------------------
+
+function applyAppearance(appearance) {
+  if (state.theme) return;
+  const base = appearance && appearance.base;
+  if (base === "light" || base === "dark") applyTheme(base);
+  else applyTheme(currentHostTheme());
+}
+
+function bindEvents() {
+  $("btnAdd").addEventListener("click", openFilesFlow);
+  $("btnOpenDir").addEventListener("click", openFilesFlow);
+  $("btnEmptyOpen").addEventListener("click", openFilesFlow);
+  $("dirClose").addEventListener("click", () => $("dirOverlay").classList.remove("show"));
+  $("dirCancel").addEventListener("click", () => $("dirOverlay").classList.remove("show"));
+  $("dirOpen").addEventListener("click", openSelectedFiles);
+  $("btnJumpLine").addEventListener("click", promptJumpToLine);
+
+  $("btnHead").addEventListener("click", () => {
+    const tab = activeTab();
+    if (!tab) return;
+    if (hasViewFilter(tab)) renderFilteredReset(tab);
+    else {
+      tab.viewLine = 1;
+      scroller.scrollTop = 0;
+      renderWindow(tab, 1);
+    }
+  });
+  $("btnTail").addEventListener("click", () => {
+    const tab = activeTab();
+    if (!tab || hasViewFilter(tab)) return;
+    scrollToTail(tab);
+  });
+  $("btnFollow").addEventListener("click", () => {
+    const tab = activeTab();
+    if (!tab || tab.mode !== "native") return;
+    setFollow(tab, !tab.follow);
+  });
+  $("btnFontDown").addEventListener("click", () => {
+    state.fontSize = Math.max(10, state.fontSize - 1);
+    applyFont();
+  });
+  $("btnFontUp").addEventListener("click", () => {
+    state.fontSize = Math.min(22, state.fontSize + 1);
+    applyFont();
+  });
+  $("fontFamilySel").value = state.fontFamily;
+  $("fontFamilySel").addEventListener("change", () => {
+    state.fontFamily = $("fontFamilySel").value;
+    applyFont();
+  });
+  $("btnTheme").addEventListener("click", () => {
+    const next = document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+    state.theme = next;
+    localStorage.setItem("lv.theme", next);
+    applyTheme(next);
+    const tab = activeTab();
+    if (tab) {
+      if (hasViewFilter(tab)) {
+        tab._fpaintKey = null;
+        renderFilteredViewport(tab);
+      } else if (tab.window) {
+        paintRows(tab, tab.window.lines, { absolute: true });
+      }
+    }
+  });
+  $("btnSettings").addEventListener("click", openSettings);
+  bindSettingsColorInputs();
+  $("btnToggleSearch").addEventListener("click", () => {
+    const opening = !isSearchBarVisible();
+    setSearchBarVisible(opening, { focus: opening });
+  });
+  $("btnToggleFilter").addEventListener("click", () => {
+    const opening = !isFilterBarVisible();
+    setFilterBarVisible(opening, { focus: opening });
+  });
+
+  $("btnSearch").addEventListener("click", startSearch);
+  $("btnPrevMatch").addEventListener("click", () => {
+    const tab = activeTab();
+    if (tab && tab.search) jumpMatch(tab, (tab.search.current < 0 ? tab.search.stored : tab.search.current) - 1);
+  });
+  $("btnNextMatch").addEventListener("click", () => {
+    const tab = activeTab();
+    if (tab && tab.search) jumpMatch(tab, (tab.search.current < 0 ? -1 : tab.search.current) + 1);
+  });
+  $("searchInput").addEventListener("keydown", (e) => {
+    if (e.key === "Enter") startSearch();
+  });
+  $("btnSearchClear").addEventListener("click", () => {
+    $("searchInput").value = "";
+    clearSearch(activeTab());
+  });
+  $("btnSearchClose").addEventListener("click", () => setSearchBarVisible(false));
+
+  $("btnFilter").addEventListener("click", startFilter);
+  $("btnFilterClear").addEventListener("click", () => clearAllFilters(activeTab()));
+  $("btnFilterClose").addEventListener("click", () => setFilterBarVisible(false));
+  $("filterInput").addEventListener("keydown", (e) => {
+    if (e.key === "Enter") startFilter();
+  });
+
+  for (const el of $("badges").children) {
+    el.addEventListener("click", () => {
+      const tab = activeTab();
+      if (!tab) return;
+      rememberPreFilterScroll(tab);
+      const lv = el.dataset.level;
+      const current = badgeState(tab, lv);
+      if (!tab.levels) tab.levels = new Set();
+      if (!tab.excludedLevels) tab.excludedLevels = new Set();
+      if (current === "neutral") {
+        tab.levels.add(lv);
+      } else if (current === "include") {
+        tab.levels.delete(lv);
+        tab.excludedLevels.add(lv);
+      } else {
+        tab.excludedLevels.delete(lv);
+      }
+      if (!tab.levels.size) tab.levels = null;
+      if (!tab.excludedLevels.size) tab.excludedLevels = null;
+      if (hasViewFilter(tab)) renderFilteredReset(tab);
+      else exitToUnfilteredView(tab);
+      updateBadges(tab);
+      updateFilterBar(tab);
+      updateStatus(tab);
+      scheduleSaveState();
+    });
+  }
+
+  $("encodingSel").addEventListener("change", () => {
+    const tab = activeTab();
+    if (!tab) return;
+    const enc = $("encodingSel").value;
+    tab.adapter
+      .setEncoding({ fileId: tab.fileId, encoding: enc })
+      .then(() => {
+        tab.encoding = enc;
+        if (hasViewFilter(tab)) renderFilteredReset(tab);
+        else exitToUnfilteredView(tab);
+        scheduleSaveState();
+      })
+      .catch((err) => toast(`切换编码失败: ${err.message || err}`));
+  });
+
+  scroller.addEventListener("scroll", () => {
+    const tab = activeTab();
+    if (!tab) return;
+    if (hasViewFilter(tab)) {
+      tab._fpaintKey = null;
+      renderFilteredViewport(tab);
+      if (scroller.scrollTop + scroller.clientHeight >= scroller.scrollHeight - 80) {
+        loadMoreFiltered(tab);
+      }
+      updateStatus(tab);
+      return;
+    }
+    if (tab.follow && !atBottom()) {
+      setFollow(tab, false);
+      showJumpChip(0);
+    }
+    if (atBottom() && tab.follow) hideJumpChip();
+    const from = lineAtScroll();
+    tab.viewLine = from;
+    if (!tab.window || Math.abs(from - tab.window.from) > Math.floor(visibleCount() / 2)) {
+      renderWindow(tab, from);
+    }
+    updateStatus(tab);
+    tab.tailSeen = Math.max(tab.tailSeen || 0, lineAtScroll() + visibleCount());
+  });
+
+  $("jumpChip").addEventListener("click", () => {
+    const tab = activeTab();
+    if (!tab) return;
+    hideJumpChip();
+    if (tab.mode === "native") setFollow(tab, true);
+    else scrollToTail(tab);
+  });
+
+  // drag & drop
+  let dragDepth = 0;
+  document.addEventListener("dragenter", (e) => {
+    e.preventDefault();
+    dragDepth += 1;
+    $("dropMask").style.display = "flex";
+  });
+  document.addEventListener("dragleave", () => {
+    dragDepth = Math.max(0, dragDepth - 1);
+    if (!dragDepth) $("dropMask").style.display = "none";
+  });
+  document.addEventListener("dragover", (e) => e.preventDefault());
+  document.addEventListener("drop", (e) => {
+    e.preventDefault();
+    dragDepth = 0;
+    $("dropMask").style.display = "none";
+    const files = [...((e.dataTransfer && e.dataTransfer.files) || [])];
+    if (!files.length) return;
+    for (const f of files) openDroppedFile(f);
+  });
+
+  // context menu dismiss
+  document.addEventListener("click", (e) => {
+    for (const id of ["ctxMenu"]) {
+      const menu = $(id);
+      if (menu.classList.contains("show") && !menu.contains(e.target)) menu.classList.remove("show");
+    }
+  });
+
+  // keyboard
+  document.addEventListener("keydown", (e) => {
+    const mod = e.ctrlKey || e.metaKey;
+    if (mod && e.shiftKey && e.key.toLowerCase() === "f") {
+      e.preventDefault();
+      setFilterBarVisible(true, { focus: true });
+    } else if (mod && e.key.toLowerCase() === "f") {
+      e.preventDefault();
+      setSearchBarVisible(true, { focus: true });
+    } else if (mod && e.key.toLowerCase() === "g") {
+      e.preventDefault();
+      promptJumpToLine();
+    } else if (e.key === "F3") {
+      e.preventDefault();
+      const tab = activeTab();
+      if (!tab || !tab.search) return;
+      jumpMatch(tab, tab.search.current + (e.shiftKey ? -1 : 1));
+    } else if (e.key === "Escape") {
+      if ($("settingsOverlay").classList.contains("show")) {
+        closeSettings();
+      } else if ($("dirOverlay").classList.contains("show")) {
+        $("dirOverlay").classList.remove("show");
+      } else if (document.activeElement === $("searchInput")) {
+        $("searchInput").blur();
+      } else if (document.activeElement === $("filterInput")) {
+        $("filterInput").blur();
+      } else if (isSearchBarVisible()) {
+        setSearchBarVisible(false);
+      } else if (isFilterBarVisible()) {
+        setFilterBarVisible(false);
+      }
+    }
+  });
+
+  bridge.on("appearance:changed", (appearance) => {
+    applyAppearance(appearance);
+  });
+}
+
+// ---------- persisted state --------------------------------------------------
+
+let saveTimer = null;
+function scheduleSaveState() {
+  clearTimeout(saveTimer);
+  saveTimer = setTimeout(async () => {
+    const tabs = state.tabs
+      .filter((t) => t.mode !== "demo")
+      .map((t) => ({
+        mode: t.mode,
+        path: t.path,
+        name: t.name,
+        size: t.size,
+        line: Math.max(1, t.viewLine || t.lastLine || 1),
+        encoding: t.encoding,
+        follow: t.follow,
+        levels: t.levels ? [...t.levels] : [],
+        excludeLevels: t.excludedLevels ? [...t.excludedLevels] : [],
+        filterQuery: t.filter && t.filter.query ? t.filter.query : "",
+        filterIsRegex: Boolean(t.filter && t.filter.isRegex),
+        filterCaseSensitive: Boolean(t.filter && t.filter.caseSensitive),
+        filterInvert: Boolean(t.filter && t.filter.invert),
+      }));
+    try {
+      await invoke("engine.saveState", { tabs, active: state.tabs.findIndex((t) => t.id === state.activeId) });
+    } catch {
+      // state saving is best-effort
+    }
+  }, 800);
+}
+
+// ---------- boot -------------------------------------------------------------
+
+async function boot() {
+  applyTheme(state.theme || currentHostTheme());
+  applyFont();
+  bindEvents();
+  try {
+    const appearance = await bridge.invoke("app.getAppearance");
+    applyAppearance(appearance);
+  } catch {
+    // appearance channel unavailable — keep matchMedia default
+  }
+  try {
+    const st = await invoke("engine.restoreState");
+    let skipped = 0;
+    for (const saved of st.tabs || []) {
+      if (saved.restorable && saved.fileId) {
+        const tab = createTab({ mode: "native", name: saved.name, path: saved.path, adapter: createNativeAdapter(), saved });
+        tab.fileId = saved.fileId;
+        tab.size = saved.size || 0;
+        tab.encoding = saved.encoding || "utf-8";
+        tab.follow = Boolean(saved.follow);
+        tab.levels = Array.isArray(saved.levels) && saved.levels.length ? new Set(saved.levels) : null;
+        tab.excludedLevels =
+          Array.isArray(saved.excludeLevels) && saved.excludeLevels.length ? new Set(saved.excludeLevels) : null;
+        tab.lastLine = Math.max(1, saved.line || 1);
+        tab.viewLine = Math.max(1, saved.line || 1);
+        tab.seenSize = saved.size || 0;
+        tab.filter = saved.filterQuery
+          ? {
+              query: String(saved.filterQuery),
+              isRegex: Boolean(saved.filterIsRegex),
+              caseSensitive: Boolean(saved.filterCaseSensitive),
+              invert: Boolean(saved.filterInvert),
+            }
+          : null;
+      } else {
+        skipped += 1;
+      }
+    }
+    if (skipped) toast(`${skipped} 个上次的拖入文件需重新拖入`);
+    const active = (st.tabs || [])[st.active] || state.tabs[0];
+    if (active && active.id != null && state.tabs.some((t) => t.id === active.id)) {
+      state.activeId = active.id;
+      renderTabs();
+      activateView();
+    } else if (state.tabs.length) {
+      state.activeId = state.tabs[0].id;
+      renderTabs();
+      activateView();
+    } else {
+      // 首次打开（无任何可恢复页签）→ 虚拟引导日志
+      renderTabs();
+      openDemoLog();
+    }
+  } catch (err) {
+    toast(`恢复浏览状态失败: ${err.message || err}`);
+    renderTabs();
+    if (!state.tabs.length) openDemoLog();
+  }
+  setInterval(tick, 400);
+}
+
+boot();

--- a/plugins/pi.log-viewer/renderer/index.html
+++ b/plugins/pi.log-viewer/renderer/index.html
@@ -1,0 +1,915 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="pi-plugin-panel-chrome" content="safe-area-v1" />
+  <title>日志查看器</title>
+  <style>
+    /* ========== 主题变量（对齐 pi-markdown 米白 / 黑夜） ========== */
+    :root,
+    :root[data-theme="light"] {
+      --c-bg: 247 245 241;
+      --c-panel: 251 250 247;
+      --c-panel2: 240 237 230;
+      --c-edge: 230 225 215;
+      --c-edge2: 213 207 194;
+      --c-accent: 51 50 47;
+      --c-accent2: 74 72 68;
+      --c-onaccent: 247 245 241;
+      --c-ink: 46 44 41;
+      --c-muted: 111 106 97;
+      --c-faint: 155 149 138;
+      --c-danger: 201 60 66;
+      --c-ok: 46 139 87;
+      --c-warn: 180 83 9;
+      --c-info: 61 107 143;
+      --c-scroll: 203 197 185;
+      --c-scroll-hover: 181 174 160;
+      --c-selection: 206 199 186;
+      --c-hl: 232 220 172;
+      --c-hl-ink: 64 50 12;
+      --c-code-bg: 251 250 247;
+      --c-code-border: 230 225 215;
+      --lv-error-bg: 201 60 66;
+      --lv-error-fg: 201 60 66;
+      --lv-warn-bg: 180 83 9;
+      --lv-warn-fg: 180 83 9;
+      --lv-info-bg: 61 107 143;
+      --lv-info-fg: 46 44 41;
+      --lv-debug-bg: 155 149 138;
+      --lv-debug-fg: 111 106 97;
+      color-scheme: light;
+    }
+
+    :root[data-theme="dark"] {
+      --c-bg: 22 22 22;
+      --c-panel: 30 30 30;
+      --c-panel2: 38 38 38;
+      --c-edge: 56 56 56;
+      --c-edge2: 74 74 74;
+      --c-accent: 245 245 245;
+      --c-accent2: 255 255 255;
+      --c-onaccent: 0 0 0;
+      --c-ink: 242 242 242;
+      --c-muted: 166 166 166;
+      --c-faint: 115 115 115;
+      --c-danger: 229 72 77;
+      --c-ok: 48 164 108;
+      --c-warn: 240 160 48;
+      --c-info: 120 160 200;
+      --c-scroll: 74 74 74;
+      --c-scroll-hover: 92 92 92;
+      --c-selection: 74 74 74;
+      --c-hl: 92 74 28;
+      --c-hl-ink: 255 233 168;
+      --c-code-bg: 30 30 30;
+      --c-code-border: 46 46 46;
+      --lv-error-bg: 229 72 77;
+      --lv-error-fg: 229 72 77;
+      --lv-warn-bg: 240 160 48;
+      --lv-warn-fg: 240 160 48;
+      --lv-info-bg: 120 160 200;
+      --lv-info-fg: 242 242 242;
+      --lv-debug-bg: 115 115 115;
+      --lv-debug-fg: 166 166 166;
+      color-scheme: dark;
+    }
+
+    :root {
+      --row-h: 20px;
+      --row-fs: 12px;
+      --log-font: "Cascadia Code", Consolas, "SF Mono", Menlo, "Courier New", monospace;
+      --pi-titlebar: var(--pi-plugin-titlebar-height, 46px);
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; }
+    body {
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      height: 100dvh;
+      /* 宿主标题栏不占文档流，内容从窗口顶边开始，状态栏贴底 */
+      padding-top: 0;
+      background: rgb(var(--c-bg));
+      color: rgb(var(--c-ink));
+      font: 13px/1.5 "Segoe UI", "PingFang SC", "Microsoft YaHei", -apple-system, BlinkMacSystemFont, sans-serif;
+      overflow: hidden;
+      user-select: none;
+      transition: background-color 0.18s ease, color 0.18s ease;
+    }
+
+    ::-webkit-scrollbar { width: 8px; height: 8px; }
+    ::-webkit-scrollbar-thumb { background: rgb(var(--c-scroll)); border-radius: 0; }
+    ::-webkit-scrollbar-thumb:hover { background: rgb(var(--c-scroll-hover)); }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::selection { background: rgb(var(--c-selection)); }
+
+    button, select, input { font: inherit; color: inherit; }
+    button {
+      background: transparent;
+      border: 1px solid rgb(var(--c-edge2));
+      border-radius: 0;
+      padding: 3px 10px;
+      cursor: pointer;
+      white-space: nowrap;
+      color: rgb(var(--c-muted));
+      transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+    }
+    button:hover { background: rgb(var(--c-panel)); color: rgb(var(--c-ink)); border-color: rgb(var(--c-edge2)); }
+    button.primary {
+      background: rgb(var(--c-accent));
+      border-color: rgb(var(--c-accent));
+      color: rgb(var(--c-onaccent));
+    }
+    button.primary:hover { background: rgb(var(--c-accent2)); border-color: rgb(var(--c-accent2)); color: rgb(var(--c-onaccent)); }
+    button.toggled {
+      background: rgb(var(--c-panel2));
+      border-color: rgb(var(--c-ink));
+      color: rgb(var(--c-ink));
+    }
+    button:disabled { opacity: 0.4; cursor: default; }
+    button.ghost {
+      border-color: transparent;
+      background: transparent;
+      color: rgb(var(--c-faint));
+      padding: 3px 6px;
+    }
+    button.ghost:hover { color: rgb(var(--c-ink)); background: rgb(var(--c-panel2)); }
+
+    input[type="text"], select {
+      background: rgb(var(--c-bg));
+      border: 1px solid rgb(var(--c-edge));
+      border-radius: 0;
+      padding: 3px 8px;
+      outline: none;
+      color: rgb(var(--c-ink));
+      user-select: text;
+      transition: border-color 0.15s ease;
+    }
+    input[type="text"]:focus { border-color: rgb(var(--c-ink)); }
+    input[type="text"]::placeholder { color: rgb(var(--c-faint)); }
+    input[type="checkbox"] { accent-color: rgb(var(--c-accent)); }
+    select {
+      padding: 2px 4px;
+      font-size: 11px;
+      color: rgb(var(--c-muted));
+    }
+    select:hover { color: rgb(var(--c-ink)); }
+
+    label {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      color: rgb(var(--c-muted));
+      font-size: 12px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    label:hover { color: rgb(var(--c-ink)); }
+
+    .spacer { flex: 1; min-width: 0; }
+
+    /* ========== 页签 ========== */
+    .tabs-bar {
+      display: flex;
+      align-items: stretch;
+      gap: 0;
+      min-height: 34px;
+      border-bottom: 1px solid rgb(var(--c-edge));
+      background: rgb(var(--c-panel));
+      flex: 0 0 auto;
+    }
+    .tabs {
+      display: flex;
+      overflow-x: auto;
+      scrollbar-width: none;
+      flex: 0 1 auto;
+    }
+    .tabs::-webkit-scrollbar { display: none; }
+    .tab {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 10px 0 14px;
+      border-right: 1px solid rgb(var(--c-edge));
+      background: transparent;
+      cursor: pointer;
+      max-width: 220px;
+      flex: 0 0 auto;
+      font-size: 12px;
+      color: rgb(var(--c-muted));
+      transition: background-color 0.15s ease, color 0.15s ease;
+    }
+    .tab:hover { background: rgb(var(--c-panel2)); color: rgb(var(--c-ink)); }
+    .tab.active {
+      background: rgb(var(--c-bg));
+      color: rgb(var(--c-ink));
+      box-shadow: inset 0 -2px 0 rgb(var(--c-accent));
+    }
+    .tab .t-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .tab .t-close {
+      border: 0; background: none; padding: 0 2px; color: rgb(var(--c-faint));
+      font-size: 11px; line-height: 1;
+    }
+    .tab .t-close:hover { color: rgb(var(--c-danger)); background: none; border: 0; }
+    .tabs-bar > .spacer { border-right: none; }
+    .tabs-bar #btnAdd {
+      border: 0;
+      border-left: 1px solid rgb(var(--c-edge));
+      color: rgb(var(--c-muted));
+      padding: 0 14px;
+      font-size: 16px;
+      line-height: 1;
+    }
+    .tabs-bar #btnAdd:hover { background: rgb(var(--c-panel2)); color: rgb(var(--c-ink)); }
+
+    /* ========== 工具栏 ========== */
+    .toolbar {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 6px 10px;
+      border-bottom: 1px solid rgb(var(--c-edge));
+      background: rgb(var(--c-panel));
+      flex: 0 0 auto;
+      overflow-x: auto;
+      scrollbar-width: none;
+    }
+    .toolbar::-webkit-scrollbar { display: none; }
+    .toolbar .sep {
+      width: 1px;
+      height: 16px;
+      background: rgb(var(--c-edge2));
+      margin: 0 6px;
+      flex: 0 0 auto;
+    }
+    .toolbar button { border-color: transparent; color: rgb(var(--c-muted)); }
+    .toolbar button:hover { border-color: rgb(var(--c-edge2)); }
+    .toolbar button.toggled { border-color: rgb(var(--c-ink)); }
+
+    /* ========== 文件信息 + 等级徽章 ========== */
+    .filebar {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 5px 12px;
+      border-bottom: 1px solid rgb(var(--c-edge));
+      min-height: 30px;
+      font-size: 12px;
+      background: rgb(var(--c-bg));
+      flex: 0 0 auto;
+    }
+    .filebar .f-name {
+      font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 36%;
+      color: rgb(var(--c-ink));
+    }
+    .filebar .f-meta { color: rgb(var(--c-faint)); white-space: nowrap; font-size: 11px; }
+    .idx-progress { color: rgb(var(--c-faint)); font-size: 11px; white-space: nowrap; }
+    .badges { display: flex; gap: 4px; margin-left: auto; }
+    .badge {
+      border: 1px solid rgb(var(--c-edge));
+      border-radius: 0;
+      padding: 1px 8px;
+      cursor: pointer;
+      font-size: 11px;
+      background: transparent;
+      white-space: nowrap;
+      color: rgb(var(--c-muted));
+      font-variant-numeric: tabular-nums;
+      transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .badge:hover { border-color: rgb(var(--c-edge2)); color: rgb(var(--c-ink)); }
+    .badge b { font-weight: 600; }
+    .badge.lv-error b { color: rgb(var(--lv-error-fg)); }
+    .badge.lv-warn b { color: rgb(var(--lv-warn-fg)); }
+    .badge.lv-info b { color: rgb(var(--lv-info-fg)); }
+    .badge.lv-debug b { color: rgb(var(--lv-debug-fg)); }
+    .badge.on {
+      background: rgb(var(--c-accent));
+      border-color: rgb(var(--c-accent));
+      color: rgb(var(--c-onaccent));
+    }
+    .badge.on b { color: rgb(var(--c-onaccent)); }
+    .badge.on::after { content: " ·仅"; font-size: 10px; opacity: 0.75; }
+    .badge.exclude {
+      background: transparent;
+      border-color: rgb(var(--c-danger));
+      color: rgb(var(--c-danger));
+    }
+    .badge.exclude b { color: rgb(var(--c-danger)); }
+    .badge.exclude::after { content: " ·排"; font-size: 10px; }
+
+    /* ========== 搜索 / 过滤条 ========== */
+    .searchbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 5px 12px;
+      border-bottom: 1px solid rgb(var(--c-edge));
+      background: rgb(var(--c-panel));
+      flex: 0 0 auto;
+      flex-wrap: wrap;
+    }
+    .searchbar.hidden { display: none; }
+    .searchbar input[type="text"] {
+      flex: 0 1 320px;
+      min-width: 140px;
+      font-size: 12px;
+    }
+    .searchbar .mode-tag {
+      flex: 0 0 auto;
+      font-size: 11px;
+      color: rgb(var(--c-faint));
+      user-select: none;
+      min-width: 2em;
+    }
+    .searchbar .mode-tag.filter { color: rgb(var(--c-muted)); }
+    .search-state {
+      color: rgb(var(--c-faint));
+      font-size: 11px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 280px;
+    }
+    .search-state b { color: rgb(var(--c-ink)); font-weight: 600; }
+
+    .icon-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 26px;
+      padding: 0;
+      border-color: transparent;
+      color: rgb(var(--c-muted));
+    }
+    .icon-btn:hover { color: rgb(var(--c-ink)); border-color: rgb(var(--c-edge2)); }
+    .icon-btn.toggled {
+      background: rgb(var(--c-panel2));
+      border-color: rgb(var(--c-ink));
+      color: rgb(var(--c-ink));
+    }
+
+    /* ========== 日志视图 ========== */
+    .view-wrap {
+      position: relative;
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      background: rgb(var(--c-bg));
+    }
+    .pin-bar {
+      flex: 0 0 auto;
+      border-bottom: 1px solid rgb(var(--c-edge));
+      background: rgb(var(--c-panel));
+      max-height: 120px;
+      overflow-y: auto;
+    }
+    .pin-bar.hidden { display: none; }
+    .pin-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 3px 10px 3px 8px;
+      font-family: var(--log-font);
+      font-size: var(--row-fs);
+      line-height: 18px;
+      border-left: 2px solid rgb(var(--c-accent));
+      background: rgb(var(--c-panel2));
+      cursor: pointer;
+      min-height: 22px;
+    }
+    .pin-row + .pin-row { border-top: 1px solid rgb(var(--c-edge)); }
+    .pin-row:hover { background: rgb(var(--c-panel)); }
+    .pin-row .pin-lno {
+      flex: 0 0 auto;
+      color: rgb(var(--c-faint));
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+      min-width: 48px;
+      text-align: right;
+      user-select: none;
+    }
+    .pin-row .pin-txt {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: rgb(var(--c-ink));
+      user-select: text;
+    }
+    .pin-row .pin-tag {
+      flex: 0 0 auto;
+      font-size: 10px;
+      color: rgb(var(--c-faint));
+      border: 1px solid rgb(var(--c-edge2));
+      padding: 0 4px;
+      user-select: none;
+    }
+    .pin-row .pin-x {
+      flex: 0 0 auto;
+      border: 0;
+      background: none;
+      color: rgb(var(--c-faint));
+      padding: 0 4px;
+      font-size: 12px;
+      line-height: 1;
+    }
+    .pin-row .pin-x:hover { color: rgb(var(--c-danger)); background: none; border: 0; }
+    #scroller {
+      position: relative;
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+      overflow-x: auto;
+      cursor: default;
+    }
+    #spacer { position: relative; width: max-content; min-width: 100%; }
+    .row {
+      position: absolute;
+      left: 0;
+      right: auto;
+      height: var(--row-h);
+      display: flex;
+      align-items: center;
+      font-family: var(--log-font);
+      font-size: var(--row-fs);
+      line-height: var(--row-h);
+      white-space: pre;
+      color: rgb(var(--c-ink));
+      background: transparent;
+    }
+    .row:hover { background: rgb(var(--c-panel2)); }
+    .row:hover .lno { background: rgb(var(--c-panel2)); }
+    .row.current {
+      background: rgb(var(--c-panel2));
+      box-shadow: inset 2px 0 0 rgb(var(--c-accent));
+    }
+    .lno {
+      position: sticky;
+      left: 0;
+      flex: 0 0 auto;
+      min-width: 60px;
+      padding: 0 8px;
+      text-align: right;
+      color: rgb(var(--c-faint));
+      background: rgb(var(--c-bg));
+      border-right: 1px solid rgb(var(--c-edge));
+      cursor: pointer;
+      user-select: none;
+      z-index: 2;
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+    }
+    .lno:hover { color: rgb(var(--c-ink)); }
+    .ltxt { padding: 0 12px; user-select: text; cursor: text; }
+    .ltxt mark {
+      background: rgb(var(--c-hl));
+      color: rgb(var(--c-hl-ink));
+      border-radius: 0;
+      padding: 0 1px;
+    }
+
+    /* 等级行：左侧色条 + 极淡底色（颜色可由设置覆盖） */
+    .row.lv-error {
+      --row-tint: rgb(var(--lv-error-bg) / 0.1);
+      box-shadow: inset 2px 0 0 rgb(var(--lv-error-fg) / 0.75);
+      color: rgb(var(--lv-error-fg));
+    }
+    .row.lv-warn {
+      --row-tint: rgb(var(--lv-warn-bg) / 0.1);
+      box-shadow: inset 2px 0 0 rgb(var(--lv-warn-fg) / 0.7);
+      color: rgb(var(--lv-warn-fg));
+    }
+    .row.lv-info {
+      --row-tint: rgb(var(--lv-info-bg) / 0.07);
+      box-shadow: inset 2px 0 0 rgb(var(--lv-info-fg) / 0.45);
+      color: rgb(var(--lv-info-fg));
+    }
+    .row.lv-debug {
+      --row-tint: rgb(var(--lv-debug-bg) / 0.05);
+      box-shadow: inset 2px 0 0 rgb(var(--lv-debug-fg) / 0.4);
+      color: rgb(var(--lv-debug-fg));
+    }
+    .row.lv-error,
+    .row.lv-warn,
+    .row.lv-info,
+    .row.lv-debug { background: var(--row-tint, transparent); }
+    .row.lv-error:hover,
+    .row.lv-warn:hover,
+    .row.lv-info:hover,
+    .row.lv-debug:hover { background: rgb(var(--c-panel2)); }
+    .row.lv-error .lno,
+    .row.lv-warn .lno,
+    .row.lv-info .lno,
+    .row.lv-debug .lno { background: rgb(var(--c-bg)); }
+    .row.lv-error:hover .lno,
+    .row.lv-warn:hover .lno,
+    .row.lv-info:hover .lno,
+    .row.lv-debug:hover .lno { background: rgb(var(--c-panel2)); }
+    .row.current.lv-error,
+    .row.current.lv-warn,
+    .row.current.lv-info,
+    .row.current.lv-debug { box-shadow: inset 2px 0 0 rgb(var(--c-accent)); }
+
+    /* ========== 设置面板 ========== */
+    .settings-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      padding: 14px 16px;
+      overflow: auto;
+    }
+    .settings-row {
+      display: grid;
+      grid-template-columns: 72px 1fr 1fr;
+      align-items: center;
+      gap: 12px;
+      font-size: 12px;
+    }
+    .settings-row .lv-label { font-weight: 600; }
+    .settings-row label.color-field {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: rgb(var(--c-muted));
+      font-size: 11px;
+    }
+    .settings-row input[type="color"] {
+      width: 36px;
+      height: 24px;
+      padding: 0;
+      border: 1px solid rgb(var(--c-edge2));
+      background: rgb(var(--c-bg));
+      cursor: pointer;
+    }
+    .settings-note {
+      padding: 0 16px 12px;
+      font-size: 11px;
+      color: rgb(var(--c-faint));
+      line-height: 1.5;
+    }
+
+    #jumpChip {
+      position: absolute;
+      right: 16px;
+      bottom: 12px;
+      display: none;
+      align-items: center;
+      gap: 6px;
+      background: rgb(var(--c-accent));
+      color: rgb(var(--c-onaccent));
+      border-radius: 0;
+      padding: 5px 12px;
+      font-size: 12px;
+      cursor: pointer;
+      z-index: 5;
+      transition: background-color 0.15s ease;
+    }
+    #jumpChip:hover { background: rgb(var(--c-accent2)); }
+
+    #dropMask {
+      position: absolute;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: rgb(var(--c-bg) / 0.88);
+      border: 1px dashed rgb(var(--c-edge2));
+      color: rgb(var(--c-muted));
+      font-size: 13px;
+      z-index: 6;
+      pointer-events: none;
+    }
+
+    #emptyState {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      color: rgb(var(--c-muted));
+      font-size: 13px;
+    }
+    #emptyState .hint { font-size: 12px; color: rgb(var(--c-faint)); }
+    #emptyState svg { opacity: 0.35; }
+
+    /* ========== 状态栏 ========== */
+    .statusbar {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      border-top: 1px solid rgb(var(--c-edge));
+      padding: 0 12px;
+      font-size: 11px;
+      color: rgb(var(--c-faint));
+      min-height: 26px;
+      background: rgb(var(--c-panel));
+      flex: 0 0 auto;
+    }
+    .statusbar select {
+      border-color: transparent;
+      background: transparent;
+      color: rgb(var(--c-faint));
+    }
+    .statusbar select:hover {
+      border-color: rgb(var(--c-edge2));
+      color: rgb(var(--c-ink));
+    }
+    .follow-state.on { color: rgb(var(--c-ok)); }
+    .follow-state.paused { color: rgb(var(--c-warn)); }
+
+    /* ========== 弹层 / 菜单 / Toast ========== */
+    .overlay {
+      position: fixed;
+      inset: 0;
+      background: rgb(0 0 0 / 0.5);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 20;
+    }
+    .overlay.show { display: flex; }
+    .sheet {
+      background: rgb(var(--c-panel2));
+      border: 1px solid rgb(var(--c-edge2));
+      border-radius: 0;
+      width: min(640px, 88vw);
+      max-height: 78vh;
+      display: flex;
+      flex-direction: column;
+    }
+    .sheet-head {
+      display: flex;
+      align-items: center;
+      padding: 12px 16px;
+      border-bottom: 1px solid rgb(var(--c-edge));
+      font-weight: 600;
+      font-size: 13px;
+      color: rgb(var(--c-ink));
+    }
+    .sheet-head .x {
+      margin-left: auto;
+      border: 0;
+      background: none;
+      color: rgb(var(--c-faint));
+      cursor: pointer;
+      font-size: 14px;
+    }
+    .sheet-head .x:hover { color: rgb(var(--c-ink)); background: none; }
+    .crumb {
+      padding: 8px 16px;
+      color: rgb(var(--c-muted));
+      font-size: 12px;
+      border-bottom: 1px solid rgb(var(--c-edge));
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      cursor: default;
+    }
+    .file-list { flex: 1; overflow: auto; padding: 4px 0; }
+    .f-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 6px 16px;
+      cursor: pointer;
+      font-size: 12.5px;
+      color: rgb(var(--c-ink));
+    }
+    .f-row:hover { background: rgb(var(--c-panel)); }
+    .f-row .f-size, .f-row .f-time { color: rgb(var(--c-faint)); font-size: 11px; white-space: nowrap; }
+    .f-row .f-size { margin-left: auto; font-variant-numeric: tabular-nums; }
+    .sheet-foot {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border-top: 1px solid rgb(var(--c-edge));
+    }
+    .sheet-foot #dirSelInfo { color: rgb(var(--c-faint)); font-size: 12px; }
+
+    .menu {
+      position: fixed;
+      display: none;
+      flex-direction: column;
+      background: rgb(var(--c-panel2));
+      border: 1px solid rgb(var(--c-edge2));
+      border-radius: 0;
+      padding: 4px 0;
+      min-width: 160px;
+      z-index: 30;
+    }
+    .menu.show { display: flex; }
+    .menu button {
+      border: 0;
+      background: none;
+      text-align: left;
+      padding: 7px 14px;
+      color: rgb(var(--c-ink));
+      font-size: 12px;
+    }
+    .menu button:hover:not(:disabled) { background: rgb(var(--c-panel)); }
+
+    #toast {
+      position: fixed;
+      right: 14px;
+      bottom: 36px;
+      background: rgb(var(--c-panel2));
+      color: rgb(var(--c-ink));
+      border: 1px solid rgb(var(--c-edge2));
+      border-radius: 0;
+      padding: 8px 14px;
+      font-size: 12px;
+      opacity: 0;
+      transform: translateY(6px);
+      transition: all 0.18s ease;
+      pointer-events: none;
+      max-width: 60vw;
+      z-index: 40;
+    }
+    #toast.show { opacity: 1; transform: none; }
+  </style>
+</head>
+<body>
+  <div class="tabs-bar">
+    <div class="tabs" id="tabs"></div>
+    <div class="spacer"></div>
+    <button id="btnAdd" title="打开文件">＋</button>
+  </div>
+
+  <div class="toolbar">
+    <button id="btnOpenDir">打开日志</button>
+    <button id="btnHead">头部</button>
+    <button id="btnTail">尾部</button>
+    <button id="btnJumpLine">跳转行</button>
+    <button id="btnFollow">实时跟随</button>
+    <div class="sep"></div>
+    <button id="btnFontDown" title="减小字号">A−</button>
+    <button id="btnFontUp" title="增大字号">A+</button>
+    <select id="fontFamilySel" title="日志字体">
+      <option value="default">等宽字体（系统）</option>
+      <option value="Consolas, monospace">Consolas</option>
+      <option value='"Cascadia Code", "Cascadia Mono", monospace'>Cascadia Code</option>
+      <option value='"SF Mono", Menlo, monospace'>SF Mono / Menlo</option>
+      <option value='"JetBrains Mono", monospace'>JetBrains Mono</option>
+      <option value='"Fira Code", monospace'>Fira Code</option>
+    </select>
+    <div class="spacer"></div>
+    <button id="btnToggleSearch" class="icon-btn" title="搜索栏（Ctrl+F）" aria-label="搜索">
+      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>
+    </button>
+    <button id="btnToggleFilter" class="icon-btn" title="过滤栏（Ctrl+Shift+F）" aria-label="过滤">
+      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 5h18l-7 8v5l-4 2v-7L3 5z"/></svg>
+    </button>
+    <button id="btnTheme" class="icon-btn" title="切换米白 / 黑夜主题" aria-label="切换主题"></button>
+    <button id="btnSettings" class="icon-btn" title="等级配色设置" aria-label="设置">
+      <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.7 1.7 0 00.3 1.8l.1.1a2 2 0 11-2.8 2.8l-.1-.1a1.7 1.7 0 00-1.8-.3 1.7 1.7 0 00-1 1.5V21a2 2 0 11-4 0v-.1a1.7 1.7 0 00-1-1.5 1.7 1.7 0 00-1.8.3l-.1.1a2 2 0 11-2.8-2.8l.1-.1a1.7 1.7 0 00.3-1.8 1.7 1.7 0 00-1.5-1H3a2 2 0 110-4h.1a1.7 1.7 0 001.5-1 1.7 1.7 0 00-.3-1.8l-.1-.1a2 2 0 112.8-2.8l.1.1a1.7 1.7 0 001.8.3h.1a1.7 1.7 0 001-1.5V3a2 2 0 114 0v.1a1.7 1.7 0 001 1.5h.1a1.7 1.7 0 001.8-.3l.1-.1a2 2 0 112.8 2.8l-.1.1a1.7 1.7 0 00-.3 1.8v.1a1.7 1.7 0 001.5 1H21a2 2 0 110 4h-.1a1.7 1.7 0 00-1.5 1z"/></svg>
+    </button>
+  </div>
+
+  <div class="filebar" id="filebar" style="display:none">
+    <span class="f-name" id="fName"></span>
+    <span class="f-meta" id="fMeta"></span>
+    <span class="idx-progress" id="idxProgress"></span>
+    <div class="badges" id="badges">
+      <span class="badge lv-error" data-level="error">ERROR <b>0</b></span>
+      <span class="badge lv-warn" data-level="warn">WARN <b>0</b></span>
+      <span class="badge lv-info" data-level="info">INFO <b>0</b></span>
+      <span class="badge lv-debug" data-level="debug">DEBUG <b>0</b></span>
+    </div>
+  </div>
+
+  <div class="searchbar hidden" id="searchbar">
+    <span class="mode-tag">搜索</span>
+    <input type="text" id="searchInput" placeholder="高亮命中并跳转（Ctrl+F / F3）" />
+    <label><input type="checkbox" id="cbRegex" /> 正则</label>
+    <label><input type="checkbox" id="cbCase" /> 大小写</label>
+    <button id="btnSearch" class="primary">搜索</button>
+    <button id="btnPrevMatch" title="上一个命中（Shift+F3）">↑</button>
+    <button id="btnNextMatch" title="下一个命中（F3）">↓</button>
+    <span class="search-state" id="searchState"></span>
+    <div class="spacer"></div>
+    <button id="btnSearchClear" class="ghost" title="清空搜索结果">清空</button>
+    <button id="btnSearchClose" class="ghost" title="隐藏搜索栏">✕</button>
+  </div>
+
+  <div class="searchbar hidden" id="filterbar">
+    <span class="mode-tag filter">过滤</span>
+    <input type="text" id="filterInput" placeholder="只显示匹配行（Ctrl+Shift+F）；可勾选隐藏匹配" />
+    <label><input type="checkbox" id="cbFilterRegex" /> 正则</label>
+    <label><input type="checkbox" id="cbFilterCase" /> 大小写</label>
+    <label><input type="checkbox" id="cbFilterInvert" title="勾选后隐藏匹配行"> 隐藏匹配</label>
+    <button id="btnFilter" class="primary">应用</button>
+    <span class="search-state" id="filterState"></span>
+    <div class="spacer"></div>
+    <button id="btnFilterClear" class="ghost" title="清空过滤与等级筛选">清空</button>
+    <button id="btnFilterClose" class="ghost" title="隐藏过滤栏">✕</button>
+  </div>
+
+  <div class="view-wrap">
+    <div class="pin-bar hidden" id="pinBar"></div>
+    <div id="scroller">
+      <div id="spacer"></div>
+    </div>
+    <div id="emptyState">
+      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2">
+        <path d="M14 3H7a2 2 0 00-2 2v14a2 2 0 002 2h10a2 2 0 002-2V8z"/>
+        <path d="M14 3v5h5"/>
+        <path d="M8 13h8M8 17h5"/>
+      </svg>
+      <div>打开 .log / .txt 日志开始查看</div>
+      <button id="btnEmptyOpen" class="primary">选择日志文件</button>
+      <div class="hint">或将 .log / .txt 文件拖入本窗口</div>
+    </div>
+    <div id="jumpChip">↓ 有新日志，点击回到底部</div>
+    <div id="dropMask">松开以打开 .log / .txt 日志文件</div>
+  </div>
+
+  <div class="statusbar">
+    <span id="stPos">—</span>
+    <span id="stLines"></span>
+    <span id="stSize"></span>
+    <span class="follow-state" id="stFollow"></span>
+    <div class="spacer"></div>
+    <select id="encodingSel" title="编码">
+      <option value="utf-8">UTF-8</option>
+      <option value="gbk">GBK</option>
+      <option value="gb18030">GB18030</option>
+    </select>
+  </div>
+
+  <div class="overlay" id="dirOverlay">
+    <div class="sheet">
+      <div class="sheet-head">选择日志文件<span class="x" id="dirClose">✕</span></div>
+      <div class="crumb" id="dirPath"></div>
+      <div class="file-list" id="fileList"></div>
+      <div class="sheet-foot">
+        <span id="dirSelInfo">未选择</span>
+        <div class="spacer"></div>
+        <button id="dirCancel">取消</button>
+        <button id="dirOpen" class="primary" disabled>打开选中</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="menu" id="ctxMenu">
+    <button id="ctxCopyLine">复制整行</button>
+    <button id="ctxCopySel">复制选中内容</button>
+    <button id="ctxPinLine">钉住此行</button>
+    <button id="ctxClearJump">清除筛选并跳转</button>
+  </div>
+
+  <div class="overlay" id="settingsOverlay">
+    <div class="sheet">
+      <div class="sheet-head">等级配色<span class="x" id="settingsClose">✕</span></div>
+      <div class="settings-note">为每个日志等级分别设置背景色与文字色。背景会以低透明度铺在行上；恢复默认请点「重置」。</div>
+      <div class="settings-grid" id="settingsGrid">
+        <div class="settings-row" data-level="error">
+          <span class="lv-label" style="color:rgb(var(--lv-error-fg))">ERROR</span>
+          <label class="color-field">背景 <input type="color" id="clrErrorBg" /></label>
+          <label class="color-field">文字 <input type="color" id="clrErrorFg" /></label>
+        </div>
+        <div class="settings-row" data-level="warn">
+          <span class="lv-label" style="color:rgb(var(--lv-warn-fg))">WARN</span>
+          <label class="color-field">背景 <input type="color" id="clrWarnBg" /></label>
+          <label class="color-field">文字 <input type="color" id="clrWarnFg" /></label>
+        </div>
+        <div class="settings-row" data-level="info">
+          <span class="lv-label" style="color:rgb(var(--lv-info-fg))">INFO</span>
+          <label class="color-field">背景 <input type="color" id="clrInfoBg" /></label>
+          <label class="color-field">文字 <input type="color" id="clrInfoFg" /></label>
+        </div>
+        <div class="settings-row" data-level="debug">
+          <span class="lv-label" style="color:rgb(var(--lv-debug-fg))">DEBUG</span>
+          <label class="color-field">背景 <input type="color" id="clrDebugBg" /></label>
+          <label class="color-field">文字 <input type="color" id="clrDebugFg" /></label>
+        </div>
+      </div>
+      <div class="sheet-foot">
+        <span id="settingsHint" style="color:var(--c-faint);font-size:12px"></span>
+        <div class="spacer"></div>
+        <button id="settingsReset">重置</button>
+        <button id="settingsDone" class="primary">完成</button>
+      </div>
+    </div>
+  </div>
+  <div id="toast"></div>
+  <input type="file" id="filePicker" accept=".log,.txt,.LOG,.TXT,text/plain" multiple style="display:none" />
+
+  <script src="level.js"></script>
+  <script src="query.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/plugins/pi.log-viewer/renderer/level.js
+++ b/plugins/pi.log-viewer/renderer/level.js
@@ -1,0 +1,88 @@
+"use strict";
+
+(function exposeLevel(root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  else root.LogLevel = api;
+})(typeof globalThis === "object" ? globalThis : this, () => {
+  const LEVEL_MAP = Object.freeze({
+    FATAL: "error",
+    ERROR: "error",
+    WARN: "warn",
+    WARNING: "warn",
+    INFO: "info",
+    DEBUG: "debug",
+    TRACE: "debug",
+  });
+  const LEVELS = Object.freeze(["error", "warn", "info", "debug", "other"]);
+  const TOKEN = "FATAL|ERROR|WARN|WARNING|INFO|DEBUG|TRACE";
+  const PIPE_RE = new RegExp(`(?:^|\\|)\\s*(${TOKEN})\\s*(?=\\||$)`, "i");
+  const BRACKET_RE = new RegExp(`(?:\\[|\\()\\s*(${TOKEN})\\s*(?:\\]|\\))`, "i");
+  const KEYED_RE = new RegExp(`(?:^|[^\\w])(?:level|severity|lvl)\\s*[:=]\\s*(${TOKEN})\\b`, "i");
+  const LEADING_RE = new RegExp(
+    `^\\s*(?:\\d{4}[-/]\\d{2}[-/]\\d{2}(?:[T ]\\d{2}:\\d{2}:\\d{2}(?:[.,]\\d{1,6})?(?:Z|[+-]\\d{2}:?\\d{2})?)?\\s*)?(?:\\[[^\\]]+\\]\\s*)?(?:[-|]\\s*)?(${TOKEN})(?=\\s|[:|,\\-]|$)`,
+    "i",
+  );
+  const DELIMITED_RE = new RegExp(`(?:^|[|\\-])\\s*(${TOKEN})\\s*(?=[|\\-:]|$)`, "i");
+  const FALLBACK_RE = new RegExp(`\\b(${TOKEN})\\b`, "i");
+
+  /** Uppercase delimited tokens — cheap indexOf fast path before regex. */
+  const QUICK_DELIMS = Object.freeze([
+    ["|ERROR|", "error"],
+    ["|FATAL|", "error"],
+    ["|WARN|", "warn"],
+    ["|WARNING|", "warn"],
+    ["|INFO|", "info"],
+    ["|DEBUG|", "debug"],
+    ["|TRACE|", "debug"],
+    ["[ERROR]", "error"],
+    ["[FATAL]", "error"],
+    ["[WARN]", "warn"],
+    ["[WARNING]", "warn"],
+    ["[INFO]", "info"],
+    ["[DEBUG]", "debug"],
+    ["[TRACE]", "debug"],
+  ]);
+
+  function normalise(raw) {
+    return raw ? LEVEL_MAP[String(raw).toUpperCase()] || null : null;
+  }
+
+  function find(line, pattern) {
+    const match = pattern.exec(line);
+    return match ? normalise(match[1]) : null;
+  }
+
+  /**
+   * Detect a level from a physical log line. Structured fields have priority;
+   * the unstructured token fallback is intentionally last so a field such as
+   * `|INFO|` wins over an ERROR mentioned by the message body.
+   */
+  function detectLevel(value) {
+    const line = String(value || "");
+    for (let i = 0; i < QUICK_DELIMS.length; i += 1) {
+      if (line.includes(QUICK_DELIMS[i][0])) return QUICK_DELIMS[i][1];
+    }
+    let level = find(line, PIPE_RE);
+    if (level) return level;
+    level = find(line, BRACKET_RE);
+    if (level) return level;
+    const keyed = KEYED_RE.exec(line);
+    level = keyed ? normalise(keyed[1]) : null;
+    if (level) return level;
+    level = find(
+      line,
+      LEADING_RE,
+    );
+    if (level) return level;
+    level = find(line, DELIMITED_RE);
+    if (level) return level;
+    return find(line, FALLBACK_RE);
+  }
+
+  function levelFromLine(value) {
+    return detectLevel(value) || "other";
+  }
+
+  return { LEVEL_MAP, LEVELS, detectLevel, levelFromLine, normalise };
+});

--- a/plugins/pi.log-viewer/renderer/query.js
+++ b/plugins/pi.log-viewer/renderer/query.js
@@ -1,0 +1,169 @@
+"use strict";
+
+(function exposeQuery(root, factory) {
+  const api = factory(
+    typeof module === "object" && module.exports ? require("./level.js") : root.LogLevel,
+  );
+  if (typeof module === "object" && module.exports) module.exports = api;
+  else root.LogQuery = api;
+})(typeof globalThis === "object" ? globalThis : this, (levelApi) => {
+  const MAX_REGEX_LEN = 200;
+  const LEVEL_ALIASES = Object.freeze({
+    error: "error",
+    fatal: "error",
+    warn: "warn",
+    warning: "warn",
+    info: "info",
+    debug: "debug",
+    trace: "debug",
+    other: "other",
+  });
+
+  function assertSafeRegex(source) {
+    if (!source || source.length > MAX_REGEX_LEN) {
+      throw new Error(`regex too long (max ${MAX_REGEX_LEN} chars)`);
+    }
+    const nestedQuantifier =
+      /\((?:[^()\\]|\\.)*[*+](?:[^()\\]|\\.)*\)\s*(?:[*+]|\{\d+,?\d*\})/.test(source) ||
+      /(?:\[[^\]]*\]|\\[dws])\s*[*+]\s*(?:[*+]|\{\d+,?\d*\})/i.test(source);
+    if (nestedQuantifier) {
+      throw new Error("regex rejected: nested quantifiers may hang (e.g. (a+)+)");
+    }
+  }
+
+  function tokenize(source, { isRegex = false } = {}) {
+    const tokens = [];
+    let value = "";
+    let quoted = false;
+    let escaped = false;
+    let hadQuote = false;
+    for (let i = 0; i < source.length; i += 1) {
+      const ch = source[i];
+      if (escaped) {
+        value += ch;
+        escaped = false;
+      } else if (ch === "\\") {
+        const next = source[i + 1];
+        if (isRegex && next && !(/["\\\s]/.test(next))) value += "\\";
+        else escaped = true;
+      } else if (ch === '"') {
+        quoted = !quoted;
+        hadQuote = true;
+      } else if (/\s/.test(ch) && !quoted) {
+        if (value || hadQuote) tokens.push({ value, quoted: hadQuote });
+        value = "";
+        hadQuote = false;
+      } else {
+        value += ch;
+      }
+    }
+    if (escaped) value += "\\";
+    if (quoted) throw new Error("unclosed quote in query");
+    if (value || hadQuote) tokens.push({ value, quoted: hadQuote });
+    return tokens;
+  }
+
+  function parseLevelList(value) {
+    const levels = value
+      .split(",")
+      .map((item) => item.trim().toLowerCase())
+      .filter(Boolean);
+    if (!levels.length) throw new Error("level filter requires a value");
+    const result = new Set();
+    for (const item of levels) {
+      const mapped = LEVEL_ALIASES[item];
+      if (!mapped) throw new Error(`unknown log level: ${item}`);
+      result.add(mapped);
+    }
+    return result;
+  }
+
+  function parseQuery(source, { isRegex = false } = {}) {
+    const tokens = tokenize(String(source || ""), { isRegex });
+    if (!tokens.length) throw new Error("query required");
+    const includeLevels = new Set();
+    const excludeLevels = new Set();
+    const includeTerms = [];
+    const excludeTerms = [];
+    for (const token of tokens) {
+      const negative = !token.quoted && token.value.startsWith("-") && token.value.length > 1;
+      const body = negative ? token.value.slice(1) : token.value;
+      const levelMatch = /^level:(.+)$/i.exec(body);
+      if (levelMatch) {
+        const target = negative ? excludeLevels : includeLevels;
+        for (const item of parseLevelList(levelMatch[1])) target.add(item);
+        continue;
+      }
+      if (!body) throw new Error("query term cannot be empty");
+      (negative ? excludeTerms : includeTerms).push(body);
+    }
+    return { source: String(source || ""), includeLevels, excludeLevels, includeTerms, excludeTerms };
+  }
+
+  function normaliseLevelFilter(value) {
+    if (!value) return null;
+    const include = new Set();
+    const exclude = new Set();
+    if (Array.isArray(value)) {
+      for (const raw of value) {
+        const mapped = levelApi.normalise(raw) || (String(raw) === "other" ? "other" : null);
+        if (mapped) include.add(mapped);
+      }
+    } else if (typeof value === "object") {
+      for (const raw of value.include || []) {
+        const mapped = levelApi.normalise(raw) || (String(raw) === "other" ? "other" : null);
+        if (mapped) include.add(mapped);
+      }
+      for (const raw of value.exclude || []) {
+        const mapped = levelApi.normalise(raw) || (String(raw) === "other" ? "other" : null);
+        if (mapped) exclude.add(mapped);
+      }
+    }
+    return include.size || exclude.size ? { include, exclude } : null;
+  }
+
+  function matchesLevelFilter(line, filter) {
+    const normalised =
+      filter && filter.include instanceof Set && filter.exclude instanceof Set ? filter : normaliseLevelFilter(filter);
+    if (!normalised) return true;
+    const level = levelApi.levelFromLine(line);
+    if (normalised.exclude.has(level)) return false;
+    return !normalised.include.size || normalised.include.has(level);
+  }
+
+  function compileTerm(term, isRegex, caseSensitive) {
+    if (isRegex) {
+      assertSafeRegex(term);
+      const regex = new RegExp(term, caseSensitive ? "" : "i");
+      return (line) => regex.test(line);
+    }
+    const needle = caseSensitive ? term : term.toLowerCase();
+    return (line) => (caseSensitive ? line : line.toLowerCase()).includes(needle);
+  }
+
+  function compileQuery({ query, isRegex = false, caseSensitive = false }) {
+    if (isRegex && String(query || "").length > MAX_REGEX_LEN) {
+      throw new Error(`regex too long (max ${MAX_REGEX_LEN} chars)`);
+    }
+    const parsed = parseQuery(query, { isRegex });
+    const positive = parsed.includeTerms.map((term) => compileTerm(term, isRegex, caseSensitive));
+    const negative = parsed.excludeTerms.map((term) => compileTerm(term, isRegex, caseSensitive));
+    const test = (value) => {
+      const line = String(value || "");
+      const level = levelApi.levelFromLine(line);
+      if (parsed.excludeLevels.has(level)) return false;
+      if (parsed.includeLevels.size && !parsed.includeLevels.has(level)) return false;
+      return positive.every((match) => match(line)) && negative.every((match) => !match(line));
+    };
+    return {
+      query: parsed.source,
+      regex: Boolean(isRegex),
+      caseSensitive: Boolean(caseSensitive),
+      includeLevels: parsed.includeLevels,
+      excludeLevels: parsed.excludeLevels,
+      test,
+    };
+  }
+
+  return { assertSafeRegex, compileQuery, matchesLevelFilter, normaliseLevelFilter, parseQuery, tokenize };
+});

--- a/plugins/pi.log-viewer/test/log-viewer.test.js
+++ b/plugins/pi.log-viewer/test/log-viewer.test.js
@@ -1,0 +1,213 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { LogEngine, createHostFileSystem } = require("../lib/log-engine.js");
+const { detectLevel } = require("../renderer/level.js");
+const { compileQuery, parseQuery } = require("../renderer/query.js");
+
+test("level detection gives structured fields priority over message text", () => {
+  assert.equal(detectLevel("2026-01-01|INFO|module|request returned ERROR text"), "info");
+  assert.equal(detectLevel("2026-01-01 12:00:00 [main] ERROR module - boom"), "error");
+  assert.equal(detectLevel("level:WARN request"), "warn");
+  assert.equal(detectLevel("ordinary line without a level"), null);
+});
+
+test("level detection fast path handles pipe and bracket tokens", () => {
+  assert.equal(detectLevel("2026-09-08 00:00:03|INFO|handler:handle:42|url_path: /x"), "info");
+  assert.equal(detectLevel("2026-09-08|ERROR|db|connection failed"), "error");
+  assert.equal(detectLevel("[DEBUG] worker idle"), "debug");
+  assert.equal(detectLevel("[WARNING] disk almost full"), "warn");
+  // lowercase delimited token still hits the slow path and is detected
+  assert.equal(detectLevel("2026-01-01|info|module|ok"), "info");
+});
+
+test("engine streams host files through stat and bounded readRange", async () => {
+  const content = Buffer.from("INFO first\nERROR second\n", "utf8");
+  const calls = [];
+  const fsApi = {
+    stat: async (filePath, grantId) => {
+      calls.push(["stat", filePath, grantId]);
+      return { size: content.length, mtimeMs: 123, ino: 7, birthtimeMs: 123 };
+    },
+    readRange: async (filePath, byteOffset, length, grantId) => {
+      calls.push(["readRange", filePath, byteOffset, length, grantId]);
+      return {
+        bytes: content.subarray(byteOffset, byteOffset + length),
+        totalSize: content.length,
+      };
+    },
+    list: async () => ({ path: "", entries: [] }),
+  };
+  const engine = new LogEngine({
+    dataPath: null,
+    capabilities: { hostReadRange: true, hostStat: true },
+    fileSystem: createHostFileSystem(fsApi),
+  });
+  try {
+    await engine.setRoot({ path: "" });
+    const opened = await engine.openFile("logs/app.log");
+    const page = await engine.page({ fileId: opened.fileId, fromLine: 1, count: 2 });
+    assert.deepEqual(page.lines.map((line) => line.text), ["INFO first", "ERROR second"]);
+    assert.ok(calls.some(([kind]) => kind === "stat"));
+    assert.ok(calls.some(([kind, filePath]) => kind === "readRange" && filePath === "logs/app.log"));
+  } finally {
+    engine.dispose();
+  }
+});
+
+test("query grammar supports AND, phrases, exclusions, and level filters", () => {
+  const and = compileQuery({ query: "timeout database" });
+  assert.equal(and.test("INFO timeout while opening database"), true);
+  assert.equal(and.test("INFO timeout while opening socket"), false);
+
+  const phrase = compileQuery({ query: '"connection refused"' });
+  assert.equal(phrase.test("ERROR: connection refused"), true);
+  assert.equal(phrase.test("ERROR: connection reset"), false);
+
+  const exclude = compileQuery({ query: "timeout -healthcheck" });
+  assert.equal(exclude.test("INFO timeout for api"), true);
+  assert.equal(exclude.test("INFO timeout for healthcheck"), false);
+
+  const levels = compileQuery({ query: "level:error,warn -level:debug" });
+  assert.equal(levels.test("ERROR request failed"), true);
+  assert.equal(levels.test("WARN retrying"), true);
+  assert.equal(levels.test("DEBUG request failed"), false);
+  const regex = compileQuery({ query: "^ERROR\\s+foo", isRegex: true });
+  assert.equal(regex.test("ERROR    foo"), true);
+  assert.deepEqual([...parseQuery('"a \\"quoted\\" phrase"').includeTerms], ['a "quoted" phrase']);
+});
+
+test("engine uses the same level filter and compiled query for native files", async () => {
+  const content = Buffer.from([
+    "2026-01-01|INFO|module|request returned ERROR text",
+    "2026-01-01|WARN|module|retrying",
+    "2026-01-01|DEBUG|module|details",
+    "plain connection refused message",
+    "2026-01-01|ERROR|module|database timeout",
+  ].join("\n"));
+  const fsApi = {
+    stat: async () => ({ size: content.length, mtimeMs: 123, ino: 7, birthtimeMs: 123 }),
+    readRange: async (_filePath, byteOffset, length) => ({
+      bytes: content.subarray(byteOffset, byteOffset + length),
+      totalSize: content.length,
+    }),
+    list: async () => ({ path: "", entries: [] }),
+  };
+  const engine = new LogEngine({
+    dataPath: null,
+    capabilities: { hostReadRange: true, hostStat: true },
+    fileSystem: createHostFileSystem(fsApi),
+  });
+  try {
+    await engine.setRoot({ path: "" });
+    const opened = await engine.openFile("sample.log");
+    const filtered = await engine.page({
+      fileId: opened.fileId,
+      fromLine: 1,
+      count: 20,
+      levels: { include: ["error", "warn"], exclude: ["debug"] },
+    });
+    assert.deepEqual(filtered.lines.map((line) => line.no), [2, 5]);
+
+    const { jobId } = await engine.searchStart({
+      fileId: opened.fileId,
+      query: "level:error database -healthcheck",
+      isRegex: false,
+      caseSensitive: false,
+    });
+    let status;
+    for (let i = 0; i < 100; i += 1) {
+      status = await engine.searchStatus({ jobId });
+      if (status.status !== "running") break;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(status.status, "done");
+    const matches = await engine.searchMatches({ jobId, offset: 0, limit: 10 });
+    assert.deepEqual(matches.matches.map((match) => match.line), [5]);
+  } finally {
+    engine.dispose();
+  }
+});
+
+function makeEngine(content) {
+  const buf = Buffer.from(content, "utf8");
+  const fsApi = {
+    stat: async () => ({ size: buf.length, mtimeMs: 1, ino: 9, birthtimeMs: 1 }),
+    readRange: async (_p, byteOffset, length) => ({
+      bytes: buf.subarray(byteOffset, byteOffset + length),
+      totalSize: buf.length,
+    }),
+    list: async () => ({ path: "", entries: [] }),
+  };
+  return new LogEngine({
+    dataPath: null,
+    capabilities: { hostReadRange: true, hostStat: true },
+    fileSystem: createHostFileSystem(fsApi),
+  });
+}
+
+test("engine text filter shows only matching lines and supports invert", async () => {
+  const engine = makeEngine(
+    [
+      "2026-01-01|INFO|app|start ok",
+      "2026-01-01|ERROR|app|database timeout",
+      "2026-01-01|INFO|app|request done",
+      "2026-01-01|WARN|app|slow query",
+      "2026-01-01|ERROR|app|connection refused",
+    ].join("\n"),
+  );
+  try {
+    await engine.setRoot({ path: "" });
+    const opened = await engine.openFile("filter.log");
+    await new Promise((r) => setTimeout(r, 20)); // let the driver index
+    const onlyErrors = await engine.page({
+      fileId: opened.fileId,
+      fromLine: 1,
+      count: 20,
+      filter: { query: "ERROR", isRegex: false, caseSensitive: true },
+    });
+    assert.deepEqual(onlyErrors.lines.map((l) => l.text), [
+      "2026-01-01|ERROR|app|database timeout",
+      "2026-01-01|ERROR|app|connection refused",
+    ]);
+
+    const hideErrors = await engine.page({
+      fileId: opened.fileId,
+      fromLine: 1,
+      count: 20,
+      filter: { query: "ERROR", isRegex: false, caseSensitive: true, invert: true },
+    });
+    assert.deepEqual(hideErrors.lines.map((l) => l.no), [1, 3, 4]);
+
+    const combined = await engine.page({
+      fileId: opened.fileId,
+      fromLine: 1,
+      count: 20,
+      levels: { include: ["error"], exclude: [] },
+      filter: { query: "database", isRegex: false, caseSensitive: false },
+    });
+    assert.deepEqual(combined.lines.map((l) => l.no), [2]);
+  } finally {
+    engine.dispose();
+  }
+});
+
+test("poll after open does not treat existing lines as new when client is synced", async () => {
+  const engine = makeEngine("line one\nline two\nline three\n");
+  try {
+    await engine.setRoot({ path: "" });
+    const opened = await engine.openFile("static.log");
+    // Sync as the renderer does after open: last seen = whatever is indexed now.
+    const first = await engine.poll({ fileId: opened.fileId, sinceLine: opened.totalLines || 0 });
+    // After indexing catch-up, a client that tracks totalLines should not get a gap.
+    const synced = await engine.poll({ fileId: opened.fileId, sinceLine: first.totalLines });
+    const append = (synced.events || []).filter((e) => e.type === "append");
+    assert.equal(append.length, 0);
+    assert.equal(synced.indexDone, true);
+    assert.equal(synced.totalLines, 3);
+  } finally {
+    engine.dispose();
+  }
+});


### PR DESCRIPTION
## Summary
Adds official source for **pi.log-viewer**（日志查看器 / Log Viewer）under `plugins/pi.log-viewer/`.

## What it does
- Streamed paging + virtual scroll for multi-GB log files
- Tail follow / rotation reload
- Search (highlight + F3) vs filter (show/hide matches, level badges)
- Pin up to 5 lines; right-click clear-filter-and-jump
- Open .log/.txt via native picker or drop; first-run demo log

## Manifest
- id: pi.log-viewer
- Bilingual i18n + ui.title (en / zh-CN)
- Permissions: ui.panel, fs.read (userSelected), clipboard.write
- pi.ui.openPanel() without a title override (host chrome)

## Tests
node --test plugins/pi.log-viewer/test/log-viewer.test.js — 7/7 pass

## Notes
- Does not touch catalog.json (market publish path remains plugins.aiuo.net / pack+publish)
- Upstream: https://github.com/Tioit-Wang/pi-plugin-log-viewer (v0.2.0 merged)
