### PR TITLE
fix(catalog): preserve release timestamps on rebuild

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "providerId": "official",
   "name": "PI-Desktop Official Plugins",
-  "updatedAt": "2026-09-12T17:13:25Z",
+  "updatedAt": "2026-09-12T17:24:19Z",
   "homepage": "https://github.com/vastsa/pi-desktop-plugins",
   "plugins": [
     {

--- a/scripts/rebuild_catalog.py
+++ b/scripts/rebuild_catalog.py
@@ -39,6 +39,23 @@ def sha256(path: Path) -> str:
 
 
 def main() -> int:
+    out = ROOT / "catalog.json"
+    existing_catalog = json.loads(out.read_text(encoding="utf-8")) if out.exists() else {}
+    existing_published_at = {}
+    for plugin in existing_catalog.get("plugins", []):
+        if not isinstance(plugin, dict):
+            continue
+        versions = plugin.get("versions", [])
+        if not isinstance(versions, list):
+            continue
+        for version_entry in versions:
+            if not isinstance(version_entry, dict):
+                continue
+            published_at = version_entry.get("publishedAt")
+            if published_at:
+                key = (plugin.get("id"), version_entry.get("version"))
+                existing_published_at[key] = published_at
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     plugins = []
     for manifest_path in sorted(PLUGINS.glob("*/manifest.json")):
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -68,7 +85,7 @@ def main() -> int:
                 "versions": [
                     {
                         "version": version,
-                        "publishedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "publishedAt": existing_published_at.get((plugin_id, version)) or now,
                         "changelog": manifest.get("changelog") or f"Release {version}",
                         "minPiDesktop": (manifest.get("engines") or {}).get("piDesktop", ">=0.2.0"),
                         "shasum": sha256(package),
@@ -85,11 +102,10 @@ def main() -> int:
         "schemaVersion": 1,
         "providerId": "official",
         "name": "PI-Desktop Official Plugins",
-        "updatedAt": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "updatedAt": now,
         "homepage": "https://github.com/vastsa/pi-desktop-plugins",
         "plugins": plugins,
     }
-    out = ROOT / "catalog.json"
     out.write_text(json.dumps(catalog, indent=2) + "\n", encoding="utf-8")
     print(f"wrote {out} ({len(plugins)} plugins)")
     return 0

--- a/tests/test_rebuild_catalog.py
+++ b/tests/test_rebuild_catalog.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_rebuild_catalog():
+    spec = importlib.util.spec_from_file_location(
+        "rebuild_catalog", ROOT / "scripts" / "rebuild_catalog.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class RebuildCatalogTests(unittest.TestCase):
+    def test_preserves_existing_publish_dates(self):
+        rebuild = load_rebuild_catalog()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            plugin_dir = root / "plugins" / "demo.hello"
+            packages_dir = root / "packages"
+            plugin_dir.mkdir(parents=True)
+            packages_dir.mkdir()
+            (plugin_dir / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "id": "demo.hello",
+                        "name": "Hello",
+                        "version": "1.0.0",
+                        "description": "A test plugin",
+                        "author": "Test",
+                        "main": "main.js",
+                        "permissions": [],
+                        "engines": {"piDesktop": ">=0.2.0"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (packages_dir / "demo.hello-1.0.0.piplug").write_bytes(b"artifact")
+            old_published_at = "2024-01-02T03:04:05Z"
+            (root / "catalog.json").write_text(
+                json.dumps(
+                    {
+                        "schemaVersion": 1,
+                        "providerId": "official",
+                        "plugins": [
+                            {
+                                "id": "demo.hello",
+                                "versions": [
+                                    {
+                                        "version": "1.0.0",
+                                        "publishedAt": old_published_at,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            original_paths = (rebuild.ROOT, rebuild.PLUGINS, rebuild.PACKAGES)
+            rebuild.ROOT = root
+            rebuild.PLUGINS = root / "plugins"
+            rebuild.PACKAGES = packages_dir
+            try:
+                self.assertEqual(rebuild.main(), 0)
+            finally:
+                rebuild.ROOT, rebuild.PLUGINS, rebuild.PACKAGES = original_paths
+
+            catalog = json.loads((root / "catalog.json").read_text(encoding="utf-8"))
+            version = catalog["plugins"][0]["versions"][0]
+            self.assertEqual(version["publishedAt"], old_published_at)
+            self.assertNotEqual(catalog["updatedAt"], old_published_at)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix catalog regeneration so existing plugin versions retain their original publishedAt values. Rebuilds now update catalog.updatedAt while assigning the current timestamp only to new versions. Regenerated catalog and added a regression test.